### PR TITLE
Build Jekyll portfolio to replace Webflow site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+_site/
+.sass-cache/
+.jekyll-cache/
+.jekyll-metadata
+vendor/
+.DS_Store

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,9 @@
+source "https://rubygems.org"
+
+gem "jekyll", "~> 4.3"
+gem "webrick", "~> 1.8"
+
+group :jekyll_plugins do
+  gem "jekyll-feed", "~> 0.17"
+  gem "jekyll-seo-tag", "~> 2.8"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,168 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    base64 (0.3.0)
+    bigdecimal (3.2.3)
+    colorator (1.1.0)
+    concurrent-ruby (1.3.5)
+    csv (3.3.5)
+    em-websocket (0.5.3)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0)
+    eventmachine (1.2.7)
+    ffi (1.17.2)
+    ffi (1.17.2-aarch64-linux-gnu)
+    ffi (1.17.2-aarch64-linux-musl)
+    ffi (1.17.2-arm-linux-gnu)
+    ffi (1.17.2-arm-linux-musl)
+    ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x86-linux-gnu)
+    ffi (1.17.2-x86-linux-musl)
+    ffi (1.17.2-x86_64-darwin)
+    ffi (1.17.2-x86_64-linux-gnu)
+    ffi (1.17.2-x86_64-linux-musl)
+    forwardable-extended (2.6.0)
+    google-protobuf (4.32.1)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.1-aarch64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.1-aarch64-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.1-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.1-x86-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.1-x86-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.1-x86_64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.1-x86_64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.1-x86_64-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    http_parser.rb (0.8.0)
+    i18n (1.14.7)
+      concurrent-ruby (~> 1.0)
+    jekyll (4.4.1)
+      addressable (~> 2.4)
+      base64 (~> 0.2)
+      colorator (~> 1.0)
+      csv (~> 3.0)
+      em-websocket (~> 0.5)
+      i18n (~> 1.0)
+      jekyll-sass-converter (>= 2.0, < 4.0)
+      jekyll-watch (~> 2.0)
+      json (~> 2.6)
+      kramdown (~> 2.3, >= 2.3.1)
+      kramdown-parser-gfm (~> 1.0)
+      liquid (~> 4.0)
+      mercenary (~> 0.3, >= 0.3.6)
+      pathutil (~> 0.9)
+      rouge (>= 3.0, < 5.0)
+      safe_yaml (~> 1.0)
+      terminal-table (>= 1.8, < 4.0)
+      webrick (~> 1.7)
+    jekyll-feed (0.17.0)
+      jekyll (>= 3.7, < 5.0)
+    jekyll-sass-converter (3.1.0)
+      sass-embedded (~> 1.75)
+    jekyll-seo-tag (2.8.0)
+      jekyll (>= 3.8, < 5.0)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    json (2.15.0)
+    kramdown (2.5.1)
+      rexml (>= 3.3.9)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    liquid (4.0.4)
+    listen (3.9.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    mercenary (0.4.0)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    public_suffix (6.0.2)
+    rake (13.3.0)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
+    rexml (3.4.4)
+    rouge (4.6.1)
+    safe_yaml (1.0.5)
+    sass-embedded (1.93.2)
+      google-protobuf (~> 4.31)
+      rake (>= 13)
+    sass-embedded (1.93.2-aarch64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-aarch64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-aarch64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-arm-linux-androideabi)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-arm-linux-gnueabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-arm-linux-musleabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-arm64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-riscv64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-riscv64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-riscv64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-x86_64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-x86_64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-x86_64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-x86_64-linux-musl)
+      google-protobuf (~> 4.31)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    unicode-display_width (2.6.0)
+    webrick (1.9.1)
+
+PLATFORMS
+  aarch64-linux-android
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-androideabi
+  arm-linux-gnu
+  arm-linux-gnueabihf
+  arm-linux-musl
+  arm-linux-musleabihf
+  arm64-darwin
+  riscv64-linux-android
+  riscv64-linux-gnu
+  riscv64-linux-musl
+  ruby
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-android
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  jekyll (~> 4.3)
+  jekyll-feed (~> 0.17)
+  jekyll-seo-tag (~> 2.8)
+  webrick (~> 1.8)
+
+BUNDLED WITH
+   2.6.7

--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
-# liamday-site
+# Liam Day — Jekyll Site
+
+This repository contains a Jekyll-powered portfolio site for product design leader Liam Day. It replaces the previous
+Webflow implementation with a fully version-controlled static site.
+
+## Getting started
+
+1. Install dependencies with Bundler:
+   ```bash
+   bundle install
+   ```
+2. Run the development server:
+   ```bash
+   bundle exec jekyll serve
+   ```
+3. Build the production site:
+   ```bash
+   bundle exec jekyll build
+   ```
+
+## Structure
+
+- `_config.yml` — Site metadata, navigation, and plugin configuration.
+- `_layouts/` — Page templates for the home page, case studies, and blog posts.
+- `_data/experience.yml` — Structured data for the experience timeline.
+- `projects/` — Case study content powered by a custom collection.
+- `_posts/` — Articles listed in the Writing section.
+- `assets/css/style.scss` — Global styles compiled by Jekyll’s Sass pipeline.
+
+## Deployment
+
+The generated site lives in the `_site` directory after running `jekyll build`. Deploy the contents of `_site` to any
+static hosting provider (e.g. GitHub Pages, Netlify, Vercel).

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,57 @@
+title: Liam Day
+name: Liam Day
+description: >-
+  Product design leader crafting inclusive digital experiences and empowering teams to deliver impactful work.
+url: https://www.liamday.co.uk
+baseurl: ""
+
+permalink: pretty
+timezone: Europe/London
+
+collections:
+  projects:
+    output: true
+    permalink: /projects/:name/
+
+plugins:
+  - jekyll-feed
+  - jekyll-seo-tag
+
+defaults:
+  - scope:
+      path: ""
+      type: "projects"
+    values:
+      layout: project
+      hero: true
+
+sass:
+  sass_dir: assets/css
+  style: compressed
+
+exclude:
+  - README.md
+  - vendor
+
+markdown: kramdown
+kramdown:
+  input: GFM
+
+nav_links:
+  - title: About
+    url: /#about
+  - title: Experience
+    url: /#experience
+  - title: Projects
+    url: /#projects
+  - title: Writing
+    url: /#writing
+  - title: Contact
+    url: /#contact
+
+social:
+  email: hello@liamday.co.uk
+  linkedin: https://www.linkedin.com/in/liamday/
+  dribbble: https://dribbble.com/liamday
+  github: https://github.com/liamday
+  medium: https://medium.com/@liamday

--- a/_data/experience.yml
+++ b/_data/experience.yml
@@ -1,0 +1,36 @@
+- title: Head of Design
+  company: Public Digital
+  period: 2022 — Present
+  location: London, UK
+  summary: Leading a distributed team of product and service designers delivering transformation programmes for governments and nonprofits.
+  highlights:
+    - Established a coaching practice that improved designer retention and progression.
+    - Embedded outcome-focused roadmaps and discovery rituals across cross-functional teams.
+    - Led pitches and engagement design for multi-million pound transformation programmes.
+- title: Director of Product Design
+  company: Thought Machine
+  period: 2019 — 2022
+  location: London, UK
+  summary: Built and scaled the product design team responsible for Vault, a core banking platform used by global financial institutions.
+  highlights:
+    - Grew the team from 4 to 22 designers and researchers while maintaining high craft quality.
+    - Implemented design ops foundations including a design system, tooling, and recruiting operations.
+    - Partnered with product and engineering leadership to define product vision and prioritise roadmap investments.
+- title: Lead Designer
+  company: NHS Digital
+  period: 2016 — 2019
+  location: Leeds & London, UK
+  summary: Led service design for national healthcare products supporting clinicians and citizens.
+  highlights:
+    - Shaped the strategy for NHS Login, ensuring accessibility and trust at national scale.
+    - Facilitated co-design workshops with clinicians and patients to improve digital pathways.
+    - Championed inclusive design practices adopted across multidisciplinary teams.
+- title: Senior Interaction Designer
+  company: UK Government Digital Service
+  period: 2013 — 2016
+  location: London, UK
+  summary: Delivered award-winning services on GOV.UK and coached departments adopting agile and user-centred practices.
+  highlights:
+    - Contributed to GOV.UK Pay and Verify alpha phases, setting direction for government-wide payments and identity.
+    - Introduced design crit culture across departments to improve collaboration and quality.
+    - Regularly spoke at conferences on service design, accessibility, and working in the open.

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,0 +1,10 @@
+<meta charset="utf-8" />
+<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>{% if page.title %}{{ page.title }} · {{ site.title }}{% else %}{{ site.title }} · Product Design Leader{% endif %}</title>
+<meta name="description" content="{{ page.description | default: site.description }}" />
+<link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+{% seo %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    {% include head.html %}
+  </head>
+  <body class="site">
+    <a class="skip-link" href="#main">Skip to content</a>
+    <header class="site-header">
+      <div class="container">
+        <a class="site-logo" href="{{ "/" | relative_url }}">{{ site.title }}</a>
+        <nav class="site-nav" aria-label="Primary">
+          <button class="site-nav__toggle" aria-expanded="false" aria-controls="primary-navigation">
+            <span class="sr-only">Menu</span>
+            <span></span>
+            <span></span>
+            <span></span>
+          </button>
+          <ul id="primary-navigation">
+            {% for link in site.nav_links %}
+            <li><a href="{{ link.url | relative_url }}">{{ link.title }}</a></li>
+            {% endfor %}
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main" class="site-main">
+      {{ content }}
+    </main>
+
+    <footer class="site-footer" id="contact">
+      <div class="container">
+        <p>Let’s collaborate. <a href="mailto:{{ site.social.email }}">{{ site.social.email }}</a></p>
+        <ul class="site-footer__social" aria-label="Social links">
+          {% if site.social.linkedin %}<li><a href="{{ site.social.linkedin }}">LinkedIn</a></li>{% endif %}
+          {% if site.social.dribbble %}<li><a href="{{ site.social.dribbble }}">Dribbble</a></li>{% endif %}
+          {% if site.social.github %}<li><a href="{{ site.social.github }}">GitHub</a></li>{% endif %}
+          {% if site.social.medium %}<li><a href="{{ site.social.medium }}">Medium</a></li>{% endif %}
+        </ul>
+        <p class="site-footer__copyright">© {{ "now" | date: "%Y" }} {{ site.title }}. Built with Jekyll.</p>
+      </div>
+    </footer>
+
+    <script>
+      const navToggle = document.querySelector('.site-nav__toggle');
+      const navList = document.querySelector('#primary-navigation');
+      navToggle?.addEventListener('click', () => {
+        const expanded = navToggle.getAttribute('aria-expanded') === 'true';
+        navToggle.setAttribute('aria-expanded', !expanded);
+        navList.classList.toggle('is-open');
+      });
+    </script>
+  </body>
+</html>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,0 +1,102 @@
+---
+layout: default
+---
+<section class="hero" id="about">
+  <div class="container">
+    <p class="eyebrow">Product Design Leader · London, UK</p>
+    <h1>Designing equitable experiences and coaching teams to deliver their best work.</h1>
+    <p>
+      Liam Day is a product design leader with over a decade of experience shaping inclusive services across government,
+      healthcare, and fintech. He helps organisations define product strategy, build healthy design cultures, and ship
+      experiences that improve lives.
+    </p>
+    <a class="button" href="mailto:{{ site.social.email }}">Start a conversation</a>
+  </div>
+</section>
+
+<section class="section" id="experience">
+  <div class="container">
+    <div class="section__header">
+      <h2>Experience</h2>
+      <p>Highlights from Liam’s journey leading multidisciplinary teams and scaling product design practices.</p>
+    </div>
+    <div class="timeline">
+      {% for role in site.data.experience %}
+      <article class="timeline__item">
+        <div class="timeline__meta">
+          <span class="timeline__time">{{ role.period }}</span>
+          <span class="timeline__location">{{ role.location }}</span>
+        </div>
+        <div class="timeline__body">
+          <h3>{{ role.title }} · {{ role.company }}</h3>
+          <p>{{ role.summary }}</p>
+          {% if role.highlights %}
+          <ul>
+            {% for highlight in role.highlights %}
+            <li>{{ highlight }}</li>
+            {% endfor %}
+          </ul>
+          {% endif %}
+        </div>
+      </article>
+      {% endfor %}
+    </div>
+  </div>
+</section>
+
+<section class="section section--alt" id="projects">
+  <div class="container">
+    <div class="section__header">
+      <h2>Selected projects</h2>
+      <p>Case studies that showcase Liam’s approach to research-driven product strategy and craft.</p>
+    </div>
+    <div class="card-grid">
+      {% assign featured_projects = site.projects | where: "hero", true %}
+      {% for project in featured_projects %}
+      <article class="card">
+        <a class="card__link" href="{{ project.url | relative_url }}">
+          <div class="card__body">
+            <h3>{{ project.title }}</h3>
+            <p>{{ project.summary }}</p>
+            <span class="card__cta">Read the case study →</span>
+          </div>
+          {% if project.thumbnail %}
+          <img src="{{ project.thumbnail | relative_url }}" alt="{{ project.thumbnail_alt | default: project.title }}" />
+          {% endif %}
+        </a>
+      </article>
+      {% endfor %}
+    </div>
+  </div>
+</section>
+
+<section class="section" id="writing">
+  <div class="container">
+    <div class="section__header">
+      <h2>Writing</h2>
+      <p>Articles and talks sharing lessons on leadership, design operations, and inclusive practices.</p>
+    </div>
+    <div class="writing-list">
+      {% for post in site.posts limit: 3 %}
+      <article class="writing-list__item">
+        <h3><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h3>
+        <p>{{ post.excerpt | strip_html | truncate: 160 }}</p>
+        <span class="writing-list__meta">{{ post.date | date: "%b %Y" }}</span>
+      </article>
+      {% endfor %}
+      {% if site.posts == empty %}
+      <p class="writing-list__empty">Writing coming soon. In the meantime, explore Liam’s latest thinking on <a href="{{ site.social.medium }}">Medium</a>.</p>
+      {% endif %}
+    </div>
+  </div>
+</section>
+
+<section class="cta">
+  <div class="container">
+    <h2>Need a partner to ship meaningful products?</h2>
+    <p>
+      From defining product visions to coaching teams, Liam can help you accelerate progress on your most important problems.
+    </p>
+    <a class="button button--secondary" href="mailto:{{ site.social.email }}">Book a call</a>
+  </div>
+</section>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,18 @@
+---
+layout: default
+---
+<article class="post">
+  <div class="container">
+    <header class="post__header">
+      <p class="post__date">{{ page.date | date: "%d %B %Y" }}</p>
+      <h1>{{ page.title }}</h1>
+      {% if page.description %}<p class="post__description">{{ page.description }}</p>{% endif %}
+    </header>
+    <div class="post__content">
+      {{ content }}
+    </div>
+    <div class="post__footer">
+      <a href="{{ '/' | relative_url }}#writing" class="post__back">← Back to writing</a>
+    </div>
+  </div>
+</article>

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -1,0 +1,20 @@
+---
+layout: default
+---
+<article class="project">
+  <div class="project__hero">
+    <div class="container">
+      <a class="project__back" href="{{ '/' | relative_url }}#projects">← Back to projects</a>
+      <h1>{{ page.title }}</h1>
+      {% if page.summary %}<p class="project__summary">{{ page.summary }}</p>{% endif %}
+      <ul class="project__meta">
+        {% if page.role %}<li><strong>Role:</strong> {{ page.role }}</li>{% endif %}
+        {% if page.year %}<li><strong>Year:</strong> {{ page.year }}</li>{% endif %}
+        {% if page.client %}<li><strong>Client:</strong> {{ page.client }}</li>{% endif %}
+      </ul>
+    </div>
+  </div>
+  <div class="container project__content">
+    {{ content }}
+  </div>
+</article>

--- a/_posts/2023-07-01-coaching-design-teams.md
+++ b/_posts/2023-07-01-coaching-design-teams.md
@@ -1,0 +1,29 @@
+---
+layout: post
+title: Coaching Rituals That Unlock Product Design Teams
+description: Practical rituals to help design leaders grow autonomy, craft, and confidence across distributed teams.
+---
+
+Leading a product design team is as much about people as it is about product. Over the years I’ve found that predictable,
+human-centred coaching rituals help designers feel supported while creating space for them to grow.
+
+## 1. Weekly one-to-ones with shared agendas
+
+A lightweight shared agenda keeps conversations focused on what matters most to each designer. I encourage teammates to
+note wins, blockers, and topics they want feedback on in advance. My role in these sessions is to listen, ask thoughtful
+questions, and identify moments where they can stretch.
+
+## 2. Critique clubs outside project work
+
+Critique isn’t just for project milestones. We run informal critique clubs where designers bring experiments, sketches,
+or provocations that may never ship. The goal is to practice giving and receiving feedback in a low-risk space, building
+trust and sharpening craft.
+
+## 3. Reflection prompts during delivery
+
+Project velocity can make it hard to pause. I integrate reflection prompts into sprint ceremonies—questions like “What’s
+the riskiest assumption we’re making?” or “Who did we learn from this week?” They help teams stay intentional about
+inclusive practices and research depth.
+
+These rituals aren’t silver bullets, but they’ve consistently grown confidence, improved outcomes, and created healthier
+design cultures wherever I’ve worked.

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,0 +1,488 @@
+---
+---
+
+$font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+$color-background: #0f172a;
+$color-surface: #f8fafc;
+$color-text: #0f172a;
+$color-muted: #475569;
+$color-accent: #0ea5e9;
+$color-accent-dark: #0284c7;
+$color-border: rgba(15, 23, 42, 0.12);
+$container-width: 68rem;
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: $font-family;
+  font-size: 18px;
+  line-height: 1.6;
+  color: $color-text;
+  background: white;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: $color-accent-dark;
+  text-decoration: none;
+  transition: color 0.2s ease;
+
+  &:hover,
+  &:focus {
+    color: $color-accent;
+  }
+}
+
+img {
+  max-width: 100%;
+  display: block;
+  border-radius: 0.75rem;
+}
+
+h1,
+h2,
+h3,
+h4 {
+  font-weight: 600;
+  line-height: 1.2;
+  color: $color-background;
+  margin: 0 0 0.75em;
+}
+
+p {
+  margin: 0 0 1.25em;
+  color: $color-muted;
+}
+
+ul {
+  padding-left: 1.5rem;
+  margin: 0 0 1.25em;
+}
+
+.container {
+  width: min(100%, $container-width);
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+.skip-link {
+  position: absolute;
+  top: -40px;
+  left: 0;
+  background: $color-background;
+  color: white;
+  padding: 0.5rem 1rem;
+  border-radius: 0 0 0.5rem 0;
+  z-index: 1000;
+
+  &:focus {
+    top: 0;
+  }
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 999;
+  background: rgba(255, 255, 255, 0.95);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid $color-border;
+
+  .container {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1.25rem 1.5rem;
+  }
+}
+
+.site-logo {
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  font-size: 1.1rem;
+}
+
+.site-nav {
+  position: relative;
+
+  ul {
+    display: flex;
+    gap: 1.25rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  a {
+    font-size: 0.95rem;
+    font-weight: 500;
+    color: $color-muted;
+
+    &:hover,
+    &:focus {
+      color: $color-background;
+    }
+  }
+}
+
+.site-nav__toggle {
+  display: none;
+  border: none;
+  background: transparent;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.5rem;
+
+  span {
+    display: block;
+    width: 1.5rem;
+    height: 2px;
+    background: $color-background;
+  }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    border: 0;
+  }
+}
+
+.hero {
+  padding: 7rem 0 4rem;
+  background: linear-gradient(135deg, #e0f2fe 0%, #f8fafc 100%);
+
+  .container {
+    max-width: 52rem;
+  }
+
+  h1 {
+    font-size: clamp(2.5rem, 5vw, 3.5rem);
+    margin-bottom: 1rem;
+  }
+
+  .eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.2em;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: $color-accent-dark;
+  }
+}
+
+.section {
+  padding: 5rem 0;
+
+  &--alt {
+    background: $color-surface;
+  }
+}
+
+.section__header {
+  max-width: 40rem;
+  margin-bottom: 2.5rem;
+
+  p {
+    font-size: 1.05rem;
+  }
+}
+
+.timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+
+  &__item {
+    display: grid;
+    grid-template-columns: minmax(0, 200px) 1fr;
+    gap: 2rem;
+    align-items: start;
+  }
+
+  &__time {
+    font-weight: 600;
+    color: $color-background;
+  }
+
+  &__location {
+    color: $color-muted;
+    font-size: 0.9rem;
+  }
+
+  &__body ul {
+    margin-top: 1rem;
+  }
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+}
+
+.card {
+  background: white;
+  border: 1px solid $color-border;
+  border-radius: 1rem;
+  overflow: hidden;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+
+  &:hover,
+  &:focus-within {
+    transform: translateY(-4px);
+    box-shadow: 0 16px 32px rgba(15, 23, 42, 0.12);
+  }
+
+  &__link {
+    display: grid;
+    height: 100%;
+    color: inherit;
+  }
+
+  &__body {
+    padding: 1.75rem;
+  }
+
+  &__cta {
+    margin-top: 1rem;
+    display: inline-block;
+    font-weight: 600;
+    color: $color-accent-dark;
+  }
+
+  img {
+    width: 100%;
+    height: 220px;
+    object-fit: cover;
+  }
+}
+
+.writing-list {
+  display: grid;
+  gap: 1.5rem;
+
+  &__item {
+    padding: 1.75rem;
+    border: 1px solid $color-border;
+    border-radius: 1rem;
+    background: white;
+  }
+
+  &__meta {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    color: $color-muted;
+  }
+
+  &__empty {
+    color: $color-muted;
+  }
+}
+
+.cta {
+  padding: 4rem 0 5rem;
+  background: $color-background;
+  color: white;
+  text-align: center;
+
+  h2 {
+    color: white;
+    margin-bottom: 1rem;
+  }
+
+  p {
+    color: rgba(255, 255, 255, 0.75);
+    margin: 0 auto 2rem;
+    max-width: 40rem;
+  }
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.85rem 1.75rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 1rem;
+  background: $color-background;
+  color: white;
+  box-shadow: 0 12px 20px rgba(15, 23, 42, 0.18);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+
+  &:hover,
+  &:focus {
+    transform: translateY(-2px);
+    box-shadow: 0 20px 32px rgba(15, 23, 42, 0.25);
+  }
+
+  &--secondary {
+    background: white;
+    color: $color-background;
+    box-shadow: none;
+
+    &:hover,
+    &:focus {
+      background: rgba(255, 255, 255, 0.9);
+    }
+  }
+}
+
+.site-footer {
+  background: white;
+  border-top: 1px solid $color-border;
+  padding: 3rem 0;
+  text-align: center;
+
+  p {
+    margin-bottom: 1rem;
+  }
+
+  &__social {
+    display: flex;
+    justify-content: center;
+    gap: 1.5rem;
+    list-style: none;
+    padding: 0;
+    margin: 0 0 1.5rem;
+
+    a {
+      color: $color-muted;
+      font-weight: 500;
+
+      &:hover,
+      &:focus {
+        color: $color-background;
+      }
+    }
+  }
+
+  &__copyright {
+    font-size: 0.85rem;
+    color: $color-muted;
+  }
+}
+
+.post {
+  padding: 6rem 0 4rem;
+
+  &__header {
+    margin-bottom: 2rem;
+  }
+
+  &__date {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.2em;
+    color: $color-muted;
+  }
+
+  &__description {
+    max-width: 40rem;
+  }
+
+  &__content {
+    max-width: 42rem;
+
+    h2 {
+      margin-top: 2.5rem;
+    }
+
+    p,
+    li {
+      color: $color-muted;
+    }
+  }
+
+  &__back {
+    display: inline-block;
+    margin-top: 3rem;
+    font-weight: 600;
+  }
+}
+
+.project {
+  &__hero {
+    padding: 6rem 0 3rem;
+    background: linear-gradient(135deg, #fdf2f8, #eff6ff);
+
+    h1 {
+      font-size: clamp(2.25rem, 5vw, 3.2rem);
+    }
+
+    .project__summary {
+      max-width: 40rem;
+      font-size: 1.1rem;
+    }
+
+    .project__meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1.5rem;
+      list-style: none;
+      padding: 0;
+      margin: 1.5rem 0 0;
+
+      li {
+        color: $color-muted;
+        font-size: 0.95rem;
+      }
+    }
+  }
+
+  &__content {
+    max-width: 48rem;
+    padding: 4rem 0 5rem;
+
+    h2 {
+      margin-top: 2.5rem;
+    }
+  }
+}
+
+.site-nav ul.is-open {
+  display: block;
+}
+
+@media (max-width: 720px) {
+  body {
+    font-size: 17px;
+  }
+
+  .site-nav ul {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    background: white;
+    border: 1px solid $color-border;
+    border-radius: 0.75rem;
+    padding: 1rem 1.25rem;
+    display: none;
+    flex-direction: column;
+    gap: 1rem;
+    min-width: 180px;
+  }
+
+  .site-nav__toggle {
+    display: flex;
+  }
+
+  .timeline__item {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+    border-left: 3px solid $color-border;
+    padding-left: 1.5rem;
+  }
+
+  .card img {
+    height: 180px;
+  }
+}

--- a/assets/images/project-nhs-login.svg
+++ b/assets/images/project-nhs-login.svg
@@ -1,0 +1,13 @@
+<svg width="1200" height="800" viewBox="0 0 1200 800" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Project placeholder</title>
+  <desc id="desc">Abstract gradient illustration</desc>
+  <defs>
+    <linearGradient id="gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0ea5e9" />
+      <stop offset="100%" stop-color="#6366f1" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#gradient)" rx="48" />
+  <circle cx="300" cy="260" r="140" fill="rgba(255,255,255,0.35)" />
+  <circle cx="860" cy="520" r="220" fill="rgba(255,255,255,0.25)" />
+</svg>

--- a/assets/images/project-placeholder.svg
+++ b/assets/images/project-placeholder.svg
@@ -1,0 +1,13 @@
+<svg width="1200" height="800" viewBox="0 0 1200 800" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Project placeholder</title>
+  <desc id="desc">Abstract gradient illustration</desc>
+  <defs>
+    <linearGradient id="gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0ea5e9" />
+      <stop offset="100%" stop-color="#6366f1" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#gradient)" rx="48" />
+  <circle cx="300" cy="260" r="140" fill="rgba(255,255,255,0.35)" />
+  <circle cx="860" cy="520" r="220" fill="rgba(255,255,255,0.25)" />
+</svg>

--- a/assets/images/project-public-digital.svg
+++ b/assets/images/project-public-digital.svg
@@ -1,0 +1,13 @@
+<svg width="1200" height="800" viewBox="0 0 1200 800" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Project placeholder</title>
+  <desc id="desc">Abstract gradient illustration</desc>
+  <defs>
+    <linearGradient id="gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0ea5e9" />
+      <stop offset="100%" stop-color="#6366f1" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#gradient)" rx="48" />
+  <circle cx="300" cy="260" r="140" fill="rgba(255,255,255,0.35)" />
+  <circle cx="860" cy="520" r="220" fill="rgba(255,255,255,0.25)" />
+</svg>

--- a/assets/images/project-thought-machine.svg
+++ b/assets/images/project-thought-machine.svg
@@ -1,0 +1,13 @@
+<svg width="1200" height="800" viewBox="0 0 1200 800" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Project placeholder</title>
+  <desc id="desc">Abstract gradient illustration</desc>
+  <defs>
+    <linearGradient id="gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0ea5e9" />
+      <stop offset="100%" stop-color="#6366f1" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#gradient)" rx="48" />
+  <circle cx="300" cy="260" r="140" fill="rgba(255,255,255,0.35)" />
+  <circle cx="860" cy="520" r="220" fill="rgba(255,255,255,0.25)" />
+</svg>

--- a/index.md
+++ b/index.md
@@ -1,0 +1,3 @@
+---
+layout: home
+---

--- a/projects/nhs-digital-login.md
+++ b/projects/nhs-digital-login.md
@@ -1,0 +1,26 @@
+---
+title: NHS Login Accessibility Improvements
+summary: Ensuring secure digital identity is inclusive for millions of UK citizens accessing healthcare services.
+role: Lead Designer
+year: 2018
+client: NHS Digital
+thumbnail: /assets/images/project-nhs-login.svg
+thumbnail_alt: NHS login screens
+---
+
+## Overview
+
+As NHS Digital prepared to scale NHS Login nationally, the team identified accessibility gaps that could block adoption by
+patients with assistive technology needs. We set out to make the service compliant and welcoming for all users.
+
+## Responsibilities
+
+* Partnered with accessibility specialists to run audits, usability testing, and assistive tech labs.
+* Led co-design sessions with visually impaired and neurodivergent participants to understand real-world contexts.
+* Collaborated with engineers to implement improvements spanning interaction design, content design, and error handling.
+
+## Outcome
+
+* Achieved WCAG 2.1 AA compliance, enabling the national launch of NHS Login to 30M+ citizens.
+* Introduced an accessibility playbook now used across NHS Digital product teams.
+* Received positive feedback from patient advocacy groups and the Government Digital Service accessibility community.

--- a/projects/public-digital-transformation.md
+++ b/projects/public-digital-transformation.md
@@ -1,0 +1,29 @@
+---
+title: Government Transformation Playbook
+summary: Accelerating public sector service redesign through an outcome-led transformation playbook.
+role: Head of Design
+year: 2023
+client: UK Government Department (confidential)
+thumbnail: /assets/images/project-public-digital.svg
+thumbnail_alt: Workshop at Public Digital
+---
+
+## Context
+
+Public Digital partners with governments and civic institutions to build the skills, teams, and capabilities needed to
+work in the open and deliver better public services. The organisation needed a repeatable transformation playbook that
+could align senior stakeholders while giving delivery teams confidence to experiment.
+
+## Approach
+
+* Led discovery interviews with directors, policy leads, and delivery teams across six departments to map shared pain
+  points.
+* Facilitated cross-functional workshops to define desired outcomes and the measures that would indicate progress.
+* Coached internal teams on service design practices, introducing new rituals such as design critiques and show & tell
+  sessions.
+
+## Impact
+
+* Established a measurable set of outcomes and success indicators adopted across three transformation programmes.
+* Reduced onboarding time for new teams by 40% through a clarified delivery model and supporting artefacts.
+* Strengthened Public Digital’s positioning in competitive bids, contributing to two multi-year contract renewals.

--- a/projects/thought-machine-design-system.md
+++ b/projects/thought-machine-design-system.md
@@ -1,0 +1,26 @@
+---
+title: Vault Design System
+summary: Scaling a unified design language for a cloud-native core banking platform across global teams.
+role: Director of Product Design
+year: 2021
+client: Thought Machine
+thumbnail: /assets/images/project-thought-machine.svg
+thumbnail_alt: Vault design system components
+---
+
+## Challenge
+
+Thought Machine’s rapid growth created inconsistencies in the Vault product experience. Teams across London, Singapore,
+and New York were shipping features independently, resulting in rework and accessibility issues.
+
+## What I did
+
+* Built a design system squad including product designers, engineers, and technical writers.
+* Defined token-based design foundations and component standards for consumer and operator experiences.
+* Introduced contribution workflows, documentation patterns, and governance rituals with product and engineering leadership.
+
+## Results
+
+* Enabled 5 product squads to ship features 30% faster by eliminating repetitive component build time.
+* Increased accessibility compliance scores from 65% to 92% through inclusive defaults and testing guidance.
+* Created a culture of shared ownership with quarterly audits and roadmap planning tied to company OKRs.


### PR DESCRIPTION
## Summary
- scaffold a Jekyll-based portfolio with navigation, hero, experience timeline, projects, and writing sections
- add case study collection, post layout, and structured data for experience content
- implement Inter-driven visual design system and update documentation for running and deploying the site

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68d97ff9355c8324992ad34be2418aa3