### PR TITLE
Fix Sass min usage for container width

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -63,7 +63,7 @@ ul {
 }
 
 .container {
-  width: min(100%, $container-width);
+  width: min(100%, #{$container-width});
   margin: 0 auto;
   padding: 0 1.5rem;
 }


### PR DESCRIPTION
## Summary
- ensure the global container width uses the CSS min() function by interpolating the Sass variable
- prevent Sass from attempting to calculate incompatible percentage and rem units during builds

## Testing
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68d9891d95b083249a930e17c6fa27e2