### PR TITLE
Fix GitHub Pages baseurl configuration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ name: Liam Day
 description: >-
   Product design leader crafting inclusive digital experiences and empowering teams to deliver impactful work.
 url: https://www.liamday.co.uk
-baseurl: ""
+baseurl: "/liamday-site"
 
 permalink: pretty
 timezone: Europe/London


### PR DESCRIPTION
## Summary
- set the Jekyll `baseurl` to `/liamday-site` so assets resolve correctly when deployed under the project site path on GitHub Pages

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68d98b99d77c8324a36802557675c344