### PR TITLE
Remove security clearance details and soften current role highlights

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -63,5 +63,4 @@ contact:
   email: liam@liamday.co.uk
   linkedin: https://www.linkedin.com/in/liammday/
   website: https://www.liamday.co.uk
-  security_clearance: DV-cleared (details on request)
   right_to_work: UK citizen

--- a/_data/cv.yml
+++ b/_data/cv.yml
@@ -17,11 +17,10 @@ employment:
     location: Remote (Cambridge, UK and Immenstadt, Germany)
     period: Sep 2023 – Present
     highlights:
-      - Conducted fortnightly QA on release candidates across iOS, Android, and Web platforms, identifying 15–20 pre-deployment bugs weekly and catching early indicators of post-deployment issues from customer reports.
-      - Facilitated rapid iteration of new features with UX teams, reducing feature request and feedback tickets by 59% and requests for information about new features by 46% year-on-year.
-      - Delivered quantitative and qualitative reporting to the CEO and CTO UK to inform product roadmapping and engineering priorities.
-      - Resolved 1,000+ complex 2nd line technical support tickets over 12 months, contributing to a 19% year-on-year reduction in routine support requests through help centre optimisation and UX improvements.
-      - Enhanced help centre UX, reducing routine queries by 21% and enabling direct-to-answer responses by Community Support Managers in 70% of remaining requests.
+      - Lead cross-platform QA for iOS, Android, and web release candidates, coordinating fixes with engineering teams prior to launch.
+      - Translate customer and partner feedback into actionable insights with UX and product managers to guide feature refinement.
+      - Prepare regular performance and roadmap updates for senior leadership, highlighting delivery risks and opportunities.
+      - Own the second-line technical support queue, managing escalations and maintaining knowledge base resources with community teams.
   - title: Senior Project Manager & Operations Manager (SO3 Dismounted Close Combat, Combat CIS School)
     company: British Army
     location: Dorset, UK

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -43,10 +43,6 @@ layout: default
             <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">Website</p>
             <a class="mt-1 inline-flex text-base font-medium text-slate-900 hover:text-brand" href="{{ site.contact.website }}">www.liamday.co.uk</a>
           </li>
-          <li class="rounded-2xl border border-slate-100 bg-white/90 p-4 shadow-sm">
-            <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">Security</p>
-            <p class="mt-1 text-base font-medium text-slate-900">{{ site.contact.security_clearance }}</p>
-          </li>
           <li class="rounded-2xl border border-slate-100 bg-white/90 p-4 shadow-sm sm:col-span-2">
             <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">Right to Work</p>
             <p class="mt-1 text-base font-medium text-slate-900">{{ site.contact.right_to_work }}</p>


### PR DESCRIPTION
## Summary
- remove the security clearance field from site configuration and the home page contact panel
- rephrase the current Outdooractive role bullet points to focus on responsibilities rather than achievements

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d994f72d108324962817e7fa4cc844