### PR TITLE
Exclude node_modules from Jekyll build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,6 +32,9 @@ sass:
 exclude:
   - README.md
   - vendor
+  - node_modules
+  - package-lock.json
+  - package.json
 
 markdown: kramdown
 kramdown:


### PR DESCRIPTION
## Summary
- update the Jekyll configuration to exclude node_modules and related package files from processing
- prevent Liquid syntax errors triggered by third-party README files during site builds

## Testing
- `bundle exec jekyll build` *(fails: jekyll executable not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d999fe49a48324ab2cf624f700bcaa