### PR TITLE
Refine gradient background and navigation behavior

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,6 +25,7 @@
             <span aria-hidden="true" class="site-nav__toggle-bar"></span>
             <span aria-hidden="true" class="site-nav__toggle-bar site-nav__toggle-bar--short"></span>
           </button>
+          <div class="site-nav__overlay" data-nav-overlay></div>
           <ul id="primary-navigation" class="site-nav__list" data-nav-list>
             {% for link in site.nav_links %}
             <li class="site-nav__item">
@@ -40,7 +41,7 @@
       {{ content }}
     </main>
 
-    <footer class="border-t border-slate-200 bg-white py-12">
+    <footer class="border-t border-slate-200 py-12">
       <div class="mx-auto flex w-full max-w-6xl flex-col gap-8 px-6 text-sm text-slate-600 sm:text-base lg:flex-row lg:items-start lg:justify-between">
         <div class="space-y-3">
           <p class="text-lg font-semibold text-slate-900">Let’s collaborate.</p>
@@ -128,11 +129,14 @@
       const header = document.querySelector('[data-site-header]');
       const nav = document.querySelector('[data-nav]');
       const navToggle = nav?.querySelector('[data-nav-toggle]');
+      const navOverlay = nav?.querySelector('[data-nav-overlay]');
       const navLinks = nav?.querySelectorAll('.site-nav__link');
+      const root = document.documentElement;
       const setMobileOpen = (state) => {
         if (!navToggle) return;
         nav?.setAttribute('data-mobile-open', state.toString());
         navToggle.setAttribute('aria-expanded', state.toString());
+        root.classList.toggle('has-mobile-nav', state);
       };
 
       const setNavCollapsed = (state) => {
@@ -202,12 +206,22 @@
         setMobileOpen(!expanded);
       });
 
+      navOverlay?.addEventListener('click', () => {
+        setMobileOpen(false);
+      });
+
       navLinks?.forEach((link) => {
         link.addEventListener('click', () => {
           if (!window.matchMedia('(min-width: 768px)').matches) {
             setMobileOpen(false);
           }
         });
+      });
+
+      window.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape' && nav?.getAttribute('data-mobile-open') === 'true') {
+          setMobileOpen(false);
+        }
       });
     </script>
   </body>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 {% assign cv = site.data.cv %}
-<section class="bg-gradient-to-br from-sky-100 via-white to-slate-100 py-20" id="profile">
+<section class="py-20" id="profile">
   <div class="mx-auto max-w-6xl px-6">
     <div class="grid gap-10 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)] lg:items-start">
       <div class="space-y-6">
@@ -66,7 +66,7 @@ layout: default
   </div>
 </section>
 
-<section class="bg-slate-900 py-16 text-slate-100" id="competencies">
+<section class="py-16 text-slate-100" id="competencies">
   <div class="mx-auto max-w-6xl px-6">
     <div class="max-w-3xl space-y-4">
       <h2 class="text-2xl font-semibold sm:text-3xl">Key competencies</h2>
@@ -115,7 +115,7 @@ layout: default
   </div>
 </section>
 
-<section class="bg-slate-100 py-16" id="projects">
+<section class="py-16" id="projects">
   <div class="mx-auto max-w-6xl px-6">
     <div class="max-w-3xl space-y-4">
       <h2 class="text-2xl font-semibold text-slate-900 sm:text-3xl">Projects</h2>
@@ -175,7 +175,7 @@ layout: default
   </div>
 </section>
 
-<section class="bg-slate-900 py-16 text-slate-100" id="connect">
+<section class="py-16 text-slate-100" id="connect">
   <div class="mx-auto max-w-4xl px-6 text-center">
     <h2 class="text-3xl font-semibold sm:text-4xl">Let’s collaborate</h2>
     <p class="mx-auto mt-4 max-w-2xl text-lg text-slate-200">

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -25,11 +25,17 @@
   --header-height-collapsed: 4.25rem;
 }
 
+html.has-mobile-nav {
+  overflow: hidden;
+}
+
 body {
   background: #030712;
   background-image: var(--sky-gradient);
   background-attachment: fixed;
+  background-repeat: no-repeat;
   background-size: cover;
+  background-position: center top;
   color: #0f172a;
   transition: background-image 1s ease;
 }
@@ -39,11 +45,46 @@ body {
   top: 0;
   left: 0;
   width: 100%;
-  z-index: 50;
+  z-index: 60;
   display: flex;
   justify-content: center;
   padding: 0 var(--header-padding-x);
   transition: transform 0.4s ease, opacity 0.4s ease;
+  isolation: isolate;
+  --header-edge: clamp(
+    var(--header-padding-x),
+    calc((100vw - var(--header-max-width)) / 2 + var(--header-padding-x)),
+    calc(100vw - var(--header-padding-x))
+  );
+  --header-brand-top: 1.75rem;
+  --header-nav-top: 1.5rem;
+}
+
+.site-header::before {
+  content: '';
+  position: absolute;
+  top: -20px;
+  left: 0;
+  right: 0;
+  height: calc(var(--header-height) + 40px);
+  background: linear-gradient(
+    180deg,
+    rgba(15, 23, 42, 0.6) 0%,
+    rgba(15, 23, 42, 0.35) 35%,
+    rgba(15, 23, 42, 0.08) 70%,
+    rgba(15, 23, 42, 0) 100%
+  );
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  -webkit-mask-image: linear-gradient(180deg, rgba(255, 255, 255, 1), rgba(255, 255, 255, 0));
+  mask-image: linear-gradient(180deg, rgba(255, 255, 255, 1), rgba(255, 255, 255, 0));
+  pointer-events: none;
+  z-index: -1;
+}
+
+.site-header[data-collapsed='true'] {
+  --header-brand-top: 1.25rem;
+  --header-nav-top: 1rem;
 }
 
 .site-header__bar {
@@ -53,7 +94,9 @@ body {
   justify-content: space-between;
   gap: 1.5rem;
   padding: 1.5rem 0;
+  min-height: var(--header-height);
   transition: padding 0.3s ease;
+  pointer-events: none;
 }
 
 .site-header[data-collapsed='true'] .site-header__bar {
@@ -61,19 +104,30 @@ body {
 }
 
 .site-header__brand {
+  position: fixed;
+  top: var(--header-brand-top);
+  left: var(--header-edge);
+  z-index: 70;
   font-size: 1.05rem;
   font-weight: 600;
   letter-spacing: -0.01em;
   color: #f8fafc;
   text-decoration: none;
-  transition: color 0.3s ease;
+  pointer-events: auto;
+  text-shadow: 0 8px 24px rgba(15, 23, 42, 0.55);
+  transition: color 0.3s ease, top 0.3s ease;
 }
 
 .site-nav {
-  position: relative;
+  position: fixed;
+  top: var(--header-nav-top);
+  right: var(--header-edge);
+  z-index: 70;
   display: flex;
   align-items: center;
   gap: 1rem;
+  pointer-events: auto;
+  transition: top 0.3s ease;
 }
 
 .site-nav__toggle {
@@ -114,20 +168,55 @@ body {
 }
 
 .site-nav__list {
-  position: absolute;
-  top: calc(100% + 1rem);
-  right: 0;
-  display: none;
+  position: fixed;
+  top: calc(var(--header-height) - 0.25rem);
+  right: var(--header-edge);
+  width: min(22rem, calc(100vw - (var(--header-edge) * 2)));
+  max-height: calc(100vh - var(--header-nav-top) - 3.5rem);
+  display: flex;
   flex-direction: column;
-  align-items: flex-end;
-  gap: 0.5rem;
+  align-items: flex-start;
+  gap: 0.75rem;
   list-style: none;
-  padding: 0;
+  padding: 1.5rem;
   margin: 0;
+  border-radius: 1.5rem;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.76), rgba(15, 23, 42, 0.55));
+  box-shadow: 0 28px 60px -35px rgba(15, 23, 42, 0.6), inset 0 1px 0 rgba(255, 255, 255, 0.18);
+  backdrop-filter: blur(24px) saturate(140%);
+  -webkit-backdrop-filter: blur(24px) saturate(140%);
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-14px) scale(0.98);
+  transform-origin: top right;
+  transition: transform 0.4s ease, opacity 0.4s ease, visibility 0.4s ease;
+  pointer-events: none;
+  overflow-y: auto;
+  z-index: 65;
 }
 
 .site-nav[data-mobile-open='true'] .site-nav__list {
-  display: flex;
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.site-nav__overlay {
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(circle at top, rgba(15, 23, 42, 0.45), rgba(2, 6, 23, 0.72));
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.4s ease, visibility 0.4s ease;
+  pointer-events: none;
+  z-index: 40;
+}
+
+.site-nav[data-mobile-open='true'] .site-nav__overlay {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
 }
 
 .site-nav__item {
@@ -158,18 +247,28 @@ body {
 
 @media (min-width: 768px) {
   .site-nav__list {
-    position: static;
-    display: flex;
+    position: relative;
+    top: auto;
+    right: auto;
+    width: auto;
+    max-height: none;
     flex-direction: row;
     align-items: center;
     gap: 0;
     padding: 0.45rem 0.65rem;
+    margin: 0;
     border-radius: 9999px;
+    background: transparent;
+    box-shadow: none;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
     opacity: 1;
-    transform: translateY(0);
-    transition: opacity 0.25s ease, transform 0.25s ease;
+    visibility: visible;
+    transform: translateY(0) scale(1);
+    pointer-events: auto;
+    overflow: visible;
     isolation: isolate;
-    overflow: hidden;
+    transition: opacity 0.25s ease, transform 0.25s ease;
   }
 
   .site-nav__list::before {
@@ -190,6 +289,7 @@ body {
     opacity: 0;
     transform: translateY(-6px);
     pointer-events: none;
+    visibility: hidden;
   }
 
   .site-nav__toggle {
@@ -198,6 +298,10 @@ body {
 
   .site-nav[data-collapsed='true'] .site-nav__toggle {
     display: inline-flex;
+  }
+
+  .site-nav__overlay {
+    display: none;
   }
 
   .site-nav__item {
@@ -222,8 +326,30 @@ body {
 }
 
 @media (max-width: 767px) {
+  .site-header {
+    --header-brand-top: 1.35rem;
+    --header-nav-top: 1.15rem;
+  }
+
+  .site-header[data-collapsed='true'] {
+    --header-brand-top: 1.05rem;
+    --header-nav-top: 0.85rem;
+  }
+
   .site-header__bar {
     padding: 1.15rem 0;
+  }
+
+  .site-nav__list {
+    top: calc(var(--header-height) - 0.5rem);
+    right: var(--header-edge);
+    left: var(--header-edge);
+    width: auto;
+  }
+
+  .site-nav__overlay {
+    backdrop-filter: blur(14px);
+    -webkit-backdrop-filter: blur(14px);
   }
 }
 
@@ -253,5 +379,21 @@ body {
 @media (min-width: 768px) {
   .site-header {
     padding-top: 0.75rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .site-header,
+  .site-header::before,
+  .site-header__brand,
+  .site-header__bar,
+  .site-nav,
+  .site-nav__list,
+  .site-nav__overlay,
+  .site-nav__toggle,
+  .site-nav__toggle-bar,
+  .site-nav__link {
+    transition-duration: 0.01ms !important;
+    transition-delay: 0ms !important;
   }
 }


### PR DESCRIPTION
## Summary
- rely on the dynamic site gradient by removing individual section background classes
- restyle the fixed header with a gradient blur backdrop and viewport-fixed brand/navigation placement
- animate the mobile navigation with a translucent overlay, Escape/overlay closing, and update supporting styles

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68dd3337fc8483248d8dd2a5f7194ddc