### PR TITLE
Add gradient-driven dynamic color palette

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -89,10 +89,65 @@
       const interpolateColor = (start, end, factor) => {
         const startRgb = hexToRgb(start);
         const endRgb = hexToRgb(end);
-        const r = interpolateChannel(startRgb.r, endRgb.r, factor);
-        const g = interpolateChannel(startRgb.g, endRgb.g, factor);
-        const b = interpolateChannel(startRgb.b, endRgb.b, factor);
-        return `rgb(${r}, ${g}, ${b})`;
+        return {
+          r: interpolateChannel(startRgb.r, endRgb.r, factor),
+          g: interpolateChannel(startRgb.g, endRgb.g, factor),
+          b: interpolateChannel(startRgb.b, endRgb.b, factor)
+        };
+      };
+
+      const rgbToString = ({ r, g, b }) => `rgb(${r}, ${g}, ${b})`;
+
+      const mixRgb = (start, end, factor = 0.5) => ({
+        r: Math.round(start.r + (end.r - start.r) * factor),
+        g: Math.round(start.g + (end.g - start.g) * factor),
+        b: Math.round(start.b + (end.b - start.b) * factor)
+      });
+
+      const srgbChannelToLinear = (value) => {
+        const channel = value / 255;
+        if (channel <= 0.04045) {
+          return channel / 12.92;
+        }
+        return Math.pow((channel + 0.055) / 1.055, 2.4);
+      };
+
+      const getRelativeLuminance = ({ r, g, b }) =>
+        0.2126 * srgbChannelToLinear(r) + 0.7152 * srgbChannelToLinear(g) + 0.0722 * srgbChannelToLinear(b);
+
+      const applyDynamicPalette = (topColor, bottomColor) => {
+        const midpoint = mixRgb(topColor, bottomColor, 0.5);
+        const luminance = getRelativeLuminance(midpoint);
+        const isDarkBackground = luminance < 0.55;
+
+        const palette = isDarkBackground
+          ? {
+              '--dynamic-text-on-background': '#f8fafc',
+              '--dynamic-text-muted': 'rgba(248, 250, 252, 0.72)',
+              '--dynamic-glass-background': 'rgba(248, 250, 252, 0.78)',
+              '--dynamic-glass-border': 'rgba(248, 250, 252, 0.45)',
+              '--dynamic-glass-text': '#0f172a',
+              '--dynamic-glass-text-muted': 'rgba(15, 23, 42, 0.72)',
+              '--dynamic-control-surface': 'rgba(248, 250, 252, 0.18)',
+              '--dynamic-control-surface-hover': 'rgba(248, 250, 252, 0.28)',
+              '--dynamic-control-text': '#0f172a'
+            }
+          : {
+              '--dynamic-text-on-background': '#0f172a',
+              '--dynamic-text-muted': 'rgba(15, 23, 42, 0.68)',
+              '--dynamic-glass-background': 'rgba(15, 23, 42, 0.58)',
+              '--dynamic-glass-border': 'rgba(15, 23, 42, 0.35)',
+              '--dynamic-glass-text': '#f8fafc',
+              '--dynamic-glass-text-muted': 'rgba(248, 250, 252, 0.78)',
+              '--dynamic-control-surface': 'rgba(15, 23, 42, 0.16)',
+              '--dynamic-control-surface-hover': 'rgba(15, 23, 42, 0.26)',
+              '--dynamic-control-text': '#f8fafc'
+            };
+
+        const rootElement = document.documentElement;
+        Object.entries(palette).forEach(([variable, value]) => {
+          rootElement.style.setProperty(variable, value);
+        });
       };
 
       const getGradientForTime = (date) => {
@@ -115,12 +170,17 @@
         const factor = Math.min(Math.max((currentTime - previousStop.time) / span, 0), 1);
         const top = interpolateColor(previousStop.top, nextStop.top, factor);
         const bottom = interpolateColor(previousStop.bottom, nextStop.bottom, factor);
-        return `linear-gradient(180deg, ${top} 0%, ${bottom} 100%)`;
+        return {
+          gradient: `linear-gradient(180deg, ${rgbToString(top)} 0%, ${rgbToString(bottom)} 100%)`,
+          top,
+          bottom
+        };
       };
 
       const applyGradient = () => {
-        const gradient = getGradientForTime(new Date());
+        const { gradient, top, bottom } = getGradientForTime(new Date());
         document.body.style.setProperty('--sky-gradient', gradient);
+        applyDynamicPalette(top, bottom);
       };
 
       applyGradient();

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -9,43 +9,43 @@ layout: default
         <p class="text-sm font-semibold uppercase tracking-[0.35em] text-sky-700">
           Ex-British Army Officer | MBA (Technology Management) Candidate
         </p>
-        <h1 class="text-3xl font-semibold leading-tight text-slate-900 sm:text-4xl lg:text-5xl">
+        <h1 class="text-dynamic text-3xl font-semibold leading-tight sm:text-4xl lg:text-5xl">
           Technical product specialist delivering resilient digital experiences.
         </h1>
-        <p class="text-lg leading-relaxed text-slate-600">
+        <p class="text-dynamic-muted text-lg leading-relaxed">
           Liam combines a decade of operational leadership with hands-on mobile app development expertise to drive product quality,
           accelerate delivery, and elevate customer experience.
         </p>
       </div>
-      <div class="glass-panel rounded-3xl border border-white/40 bg-white/80 p-6 shadow-soft-xl ring-1 ring-slate-100">
+      <div class="glass-panel glass-dynamic ring-dynamic rounded-3xl border p-6 shadow-soft-xl ring-1">
         <div class="flex items-center justify-between gap-4">
-          <p class="text-sm font-semibold uppercase tracking-[0.2em] text-slate-500">Key contact details</p>
+          <p class="text-on-glass-muted text-sm font-semibold uppercase tracking-[0.2em]">Key contact details</p>
           <span class="hidden rounded-full bg-brand/10 px-3 py-1 text-xs font-medium text-brand lg:inline-flex">Always open to new conversations</span>
         </div>
         <ul class="mt-6 grid gap-4 sm:grid-cols-2">
-          <li class="rounded-2xl border border-slate-100 bg-white/90 p-4 shadow-sm">
-            <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">Location</p>
-            <p class="mt-1 text-base font-medium text-slate-900">{{ site.contact.location }}</p>
+          <li class="glass-dynamic rounded-2xl border p-4 shadow-sm">
+            <p class="text-on-glass-muted text-xs font-semibold uppercase tracking-wide">Location</p>
+            <p class="text-on-glass mt-1 text-base font-medium">{{ site.contact.location }}</p>
           </li>
-          <li class="rounded-2xl border border-slate-100 bg-white/90 p-4 shadow-sm">
-            <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">Phone</p>
-            <a class="mt-1 inline-flex text-base font-medium text-slate-900 hover:text-brand" href="tel:{{ site.contact.phone | replace: ' ', '' }}">{{ site.contact.phone }}</a>
+          <li class="glass-dynamic rounded-2xl border p-4 shadow-sm">
+            <p class="text-on-glass-muted text-xs font-semibold uppercase tracking-wide">Phone</p>
+            <a class="text-on-glass mt-1 inline-flex text-base font-medium hover:text-brand" href="tel:{{ site.contact.phone | replace: ' ', '' }}">{{ site.contact.phone }}</a>
           </li>
-          <li class="rounded-2xl border border-slate-100 bg-white/90 p-4 shadow-sm">
-            <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">Email</p>
-            <a class="mt-1 inline-flex text-base font-medium text-slate-900 hover:text-brand" href="mailto:{{ site.contact.email }}">{{ site.contact.email }}</a>
+          <li class="glass-dynamic rounded-2xl border p-4 shadow-sm">
+            <p class="text-on-glass-muted text-xs font-semibold uppercase tracking-wide">Email</p>
+            <a class="text-on-glass mt-1 inline-flex text-base font-medium hover:text-brand" href="mailto:{{ site.contact.email }}">{{ site.contact.email }}</a>
           </li>
-          <li class="rounded-2xl border border-slate-100 bg-white/90 p-4 shadow-sm">
-            <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">LinkedIn</p>
-            <a class="mt-1 inline-flex text-base font-medium text-slate-900 hover:text-brand" href="{{ site.contact.linkedin }}">linkedin.com/in/liammday</a>
+          <li class="glass-dynamic rounded-2xl border p-4 shadow-sm">
+            <p class="text-on-glass-muted text-xs font-semibold uppercase tracking-wide">LinkedIn</p>
+            <a class="text-on-glass mt-1 inline-flex text-base font-medium hover:text-brand" href="{{ site.contact.linkedin }}">linkedin.com/in/liammday</a>
           </li>
-          <li class="rounded-2xl border border-slate-100 bg-white/90 p-4 shadow-sm">
-            <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">Website</p>
-            <a class="mt-1 inline-flex text-base font-medium text-slate-900 hover:text-brand" href="{{ site.contact.website }}">www.liamday.co.uk</a>
+          <li class="glass-dynamic rounded-2xl border p-4 shadow-sm">
+            <p class="text-on-glass-muted text-xs font-semibold uppercase tracking-wide">Website</p>
+            <a class="text-on-glass mt-1 inline-flex text-base font-medium hover:text-brand" href="{{ site.contact.website }}">www.liamday.co.uk</a>
           </li>
-          <li class="rounded-2xl border border-slate-100 bg-white/90 p-4 shadow-sm sm:col-span-2">
-            <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">Right to Work</p>
-            <p class="mt-1 text-base font-medium text-slate-900">{{ site.contact.right_to_work }}</p>
+          <li class="glass-dynamic rounded-2xl border p-4 shadow-sm sm:col-span-2">
+            <p class="text-on-glass-muted text-xs font-semibold uppercase tracking-wide">Right to Work</p>
+            <p class="text-on-glass mt-1 text-base font-medium">{{ site.contact.right_to_work }}</p>
           </li>
         </ul>
       </div>
@@ -57,9 +57,9 @@ layout: default
   <div class="mx-auto max-w-6xl px-6">
     <div class="grid gap-10 lg:grid-cols-[minmax(0,0.45fr)_minmax(0,1fr)]">
       <div>
-        <h2 class="text-2xl font-semibold text-slate-900 sm:text-3xl">Profile</h2>
+        <h2 class="text-dynamic text-2xl font-semibold sm:text-3xl">Profile</h2>
       </div>
-      <div class="text-lg leading-relaxed text-slate-600">
+      <div class="text-dynamic-muted text-lg leading-relaxed">
         <p>{{ cv.profile }}</p>
       </div>
     </div>
@@ -86,8 +86,8 @@ layout: default
 <section class="py-16" id="experience">
   <div class="mx-auto max-w-6xl px-6">
     <div class="max-w-3xl space-y-4">
-      <h2 class="text-2xl font-semibold text-slate-900 sm:text-3xl">Employment</h2>
-      <p class="text-lg text-slate-600">Leadership roles spanning mobile software, large-scale training programmes, and secure communications operations.</p>
+      <h2 class="text-dynamic text-2xl font-semibold sm:text-3xl">Employment</h2>
+      <p class="text-dynamic-muted text-lg">Leadership roles spanning mobile software, large-scale training programmes, and secure communications operations.</p>
     </div>
     <div class="mt-12 space-y-12 border-l border-slate-200 pl-8">
       {% for role in cv.employment %}
@@ -101,9 +101,9 @@ layout: default
           <span>{{ role.location }}</span>
         </div>
         <div class="space-y-3">
-          <h3 class="text-xl font-semibold text-slate-900">{{ role.title }}</h3>
-          <p class="text-base font-medium text-slate-600">{{ role.company }}</p>
-          <ul class="list-disc space-y-2 pl-5 text-base leading-relaxed text-slate-600">
+          <h3 class="text-dynamic text-xl font-semibold">{{ role.title }}</h3>
+          <p class="text-dynamic-muted text-base font-medium">{{ role.company }}</p>
+          <ul class="text-dynamic-muted list-disc space-y-2 pl-5 text-base leading-relaxed">
             {% for highlight in role.highlights %}
             <li>{{ highlight }}</li>
             {% endfor %}
@@ -118,8 +118,8 @@ layout: default
 <section class="py-16" id="projects">
   <div class="mx-auto max-w-6xl px-6">
     <div class="max-w-3xl space-y-4">
-      <h2 class="text-2xl font-semibold text-slate-900 sm:text-3xl">Projects</h2>
-      <p class="text-lg text-slate-600">Selected case studies from apps and digital platforms Liam has shaped across defence and outdoor sectors.</p>
+      <h2 class="text-dynamic text-2xl font-semibold sm:text-3xl">Projects</h2>
+      <p class="text-dynamic-muted text-lg">Selected case studies from apps and digital platforms Liam has shaped across defence and outdoor sectors.</p>
     </div>
     <div class="mt-12 grid gap-6 sm:grid-cols-2">
       {% assign ordered_projects = site.projects | sort: "order" %}
@@ -145,7 +145,7 @@ layout: default
   <div class="mx-auto max-w-6xl px-6">
     <div class="grid gap-10 lg:grid-cols-[minmax(0,0.45fr)_minmax(0,1fr)]">
       <div>
-        <h2 class="text-2xl font-semibold text-slate-900 sm:text-3xl">Education &amp; Certifications</h2>
+        <h2 class="text-dynamic text-2xl font-semibold sm:text-3xl">Education &amp; Certifications</h2>
       </div>
       <div class="grid gap-8 md:grid-cols-2">
         <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -19,6 +19,15 @@
 
 :root {
   --sky-gradient: linear-gradient(180deg, #0b1936 0%, #030712 100%);
+  --dynamic-text-on-background: #0f172a;
+  --dynamic-text-muted: rgba(15, 23, 42, 0.72);
+  --dynamic-glass-background: rgba(248, 250, 252, 0.78);
+  --dynamic-glass-border: rgba(248, 250, 252, 0.45);
+  --dynamic-glass-text: #0f172a;
+  --dynamic-glass-text-muted: rgba(15, 23, 42, 0.72);
+  --dynamic-control-surface: rgba(255, 255, 255, 0.14);
+  --dynamic-control-surface-hover: rgba(255, 255, 255, 0.24);
+  --dynamic-control-text: #f8fafc;
   --header-max-width: 72rem;
   --header-padding-x: 1.5rem;
   --header-height: 5.75rem;
@@ -36,8 +45,41 @@ body {
   background-repeat: no-repeat;
   background-size: cover;
   background-position: center top;
-  color: #0f172a;
-  transition: background-image 1s ease;
+  color: var(--dynamic-text-on-background);
+  transition: background-image 1s ease, color 0.6s ease;
+}
+
+.text-dynamic {
+  color: var(--dynamic-text-on-background);
+  transition: color 0.6s ease;
+}
+
+.text-dynamic-muted {
+  color: var(--dynamic-text-muted);
+  transition: color 0.6s ease;
+}
+
+.text-on-glass {
+  color: var(--dynamic-glass-text);
+  transition: color 0.6s ease;
+}
+
+.text-on-glass-muted {
+  color: var(--dynamic-glass-text-muted);
+  transition: color 0.6s ease;
+}
+
+.glass-dynamic {
+  background: var(--dynamic-glass-background);
+  border-color: var(--dynamic-glass-border);
+  color: var(--dynamic-glass-text);
+  backdrop-filter: blur(24px);
+  -webkit-backdrop-filter: blur(24px);
+  transition: background-color 0.6s ease, border-color 0.6s ease, color 0.6s ease, box-shadow 0.6s ease;
+}
+
+.ring-dynamic {
+  --tw-ring-color: var(--dynamic-glass-border);
 }
 
 .site-header {
@@ -111,7 +153,7 @@ body {
   font-size: 1.05rem;
   font-weight: 600;
   letter-spacing: -0.01em;
-  color: #f8fafc;
+  color: var(--dynamic-text-on-background);
   text-decoration: none;
   pointer-events: auto;
   text-shadow: 0 8px 24px rgba(15, 23, 42, 0.55);
@@ -138,15 +180,15 @@ body {
   height: 2.75rem;
   border-radius: 9999px;
   border: none;
-  background: rgba(255, 255, 255, 0.12);
-  color: #f8fafc;
+  background: var(--dynamic-control-surface);
+  color: var(--dynamic-control-text);
   cursor: pointer;
   transition: background 0.3s ease, transform 0.3s ease, opacity 0.3s ease;
 }
 
 .site-nav__toggle:hover,
 .site-nav__toggle:focus-visible {
-  background: rgba(255, 255, 255, 0.24);
+  background: var(--dynamic-control-surface-hover);
   outline: none;
 }
 
@@ -232,7 +274,7 @@ body {
   font-size: 0.95rem;
   font-weight: 500;
   letter-spacing: 0.02em;
-  color: #f8fafc;
+  color: var(--dynamic-text-on-background);
   text-decoration: none;
   text-shadow: 0 8px 20px rgba(15, 23, 42, 0.6);
   transition: color 0.2s ease, transform 0.2s ease;
@@ -240,7 +282,8 @@ body {
 
 .site-nav__link:hover,
 .site-nav__link:focus-visible {
-  color: #fff;
+  color: var(--dynamic-text-on-background);
+  opacity: 0.78;
   transform: translateY(-1px);
   outline: none;
 }


### PR DESCRIPTION
## Summary
- derive a contrast-aware palette from the rotating background gradient and expose it as CSS custom properties
- update global styles and hero markup to consume the new dynamic palette for text and liquid glass surfaces

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68dd374eff408324993349673c81f9fe