### PR TITLE
Add GSAP liquid glass animation to hero contact panel

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -61,6 +61,12 @@
       </div>
     </footer>
 
+    <script
+      src="https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/gsap.min.js"
+      integrity="sha384-hYHKH/s7frgVxH98p4J8C79yD6qxQFDoa+iMlO07mg51gUgJOMJ2K72I1H9EZGQw"
+      crossorigin="anonymous"
+    ></script>
+    <script src="{{ '/assets/js/liquid-glass-gsap.js' | relative_url }}"></script>
     <script>
       const gradientStops = [
         { time: 0, top: '#020024', bottom: '#090979' },

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -17,10 +17,32 @@ layout: default
           accelerate delivery, and elevate customer experience.
         </p>
       </div>
-      <div class="glass-panel glass-dynamic ring-dynamic rounded-3xl border p-6 shadow-soft-xl ring-1">
+      <div class="glass-panel glass-dynamic ring-dynamic rounded-3xl border p-6 shadow-soft-xl ring-1" data-liquid-glass-panel>
         <div class="flex items-center justify-between gap-4">
-          <p class="text-on-glass-muted text-sm font-semibold uppercase tracking-[0.2em]">Key contact details</p>
+          <div class="space-y-1">
+            <p class="text-on-glass-muted text-sm font-semibold uppercase tracking-[0.2em]">Key contact details</p>
+            <span class="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-on-glass-muted liquid-glass-status lg:hidden">
+              <span class="liquid-glass-pip"></span>
+              Liquid glass active
+            </span>
+          </div>
           <span class="hidden rounded-full bg-brand/10 px-3 py-1 text-xs font-medium text-brand lg:inline-flex">Always open to new conversations</span>
+          <div class="liquid-glass-badge" data-liquid-glass>
+            <div class="liquid-glass-badge__shimmer"></div>
+            <svg class="liquid-glass-badge__icon" viewBox="0 0 48 48" aria-hidden="true">
+              <defs>
+                <linearGradient id="liquid-glass-icon-gradient" x1="0%" x2="100%" y1="0%" y2="100%">
+                  <stop offset="0%" stop-color="rgba(255,255,255,0.9)" />
+                  <stop offset="100%" stop-color="rgba(148,163,184,0.55)" />
+                </linearGradient>
+              </defs>
+              <g fill="none" stroke="url(#liquid-glass-icon-gradient)" stroke-width="2.75" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="10" y="12" width="28" height="24" rx="7" ry="7"></rect>
+                <path d="M16 20h16M16 28h9"></path>
+                <circle cx="31.5" cy="27.5" r="3.5"></circle>
+              </g>
+            </svg>
+          </div>
         </div>
         <ul class="mt-6 grid gap-4 sm:grid-cols-2">
           <li class="glass-dynamic rounded-2xl border p-4 shadow-sm">

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -78,6 +78,104 @@ body {
   transition: background-color 0.6s ease, border-color 0.6s ease, color 0.6s ease, box-shadow 0.6s ease;
 }
 
+.glass-panel {
+  position: relative;
+  overflow: hidden;
+}
+
+.glass-panel > *:not(.liquid-glass-layer) {
+  position: relative;
+  z-index: 2;
+}
+
+.liquid-glass-layer {
+  position: absolute;
+  inset: -35%;
+  border-radius: 32%;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.5), rgba(148, 163, 184, 0.15) 45%, transparent 70%);
+  filter: blur(16px);
+  mix-blend-mode: screen;
+  opacity: 0.65;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.liquid-glass-layer--cyan {
+  background: radial-gradient(circle at 70% 70%, rgba(59, 130, 246, 0.35), rgba(14, 165, 233, 0.12) 45%, transparent 70%);
+}
+
+.liquid-glass-layer--magenta {
+  background: radial-gradient(circle at 50% 20%, rgba(244, 114, 182, 0.45), rgba(255, 255, 255, 0.15) 50%, transparent 78%);
+}
+
+.liquid-glass-badge {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 4.5rem;
+  height: 4.5rem;
+  border-radius: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.25), rgba(148, 163, 184, 0.06));
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06), 0 22px 45px rgba(15, 23, 42, 0.2);
+  overflow: hidden;
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  transition: transform 0.6s ease;
+}
+
+.liquid-glass-badge__shimmer {
+  position: absolute;
+  inset: -40%;
+  background: conic-gradient(from 220deg, rgba(255, 255, 255, 0.28), rgba(59, 130, 246, 0.2), rgba(14, 165, 233, 0.12), rgba(255, 255, 255, 0.28));
+  opacity: 0.6;
+  filter: blur(20px);
+  mix-blend-mode: screen;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.liquid-glass-badge__icon {
+  position: relative;
+  width: 2.75rem;
+  height: 2.75rem;
+  z-index: 1;
+}
+
+.liquid-glass-pip {
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: 999px;
+  background: radial-gradient(circle at 30% 30%, rgba(59, 130, 246, 0.95), rgba(14, 165, 233, 0.35));
+  box-shadow: 0 0 0.5rem rgba(59, 130, 246, 0.45);
+  animation: liquid-pip-pulse 3s ease-in-out infinite;
+}
+
+.liquid-glass-status {
+  color: inherit;
+  opacity: 0.72;
+  letter-spacing: 0.3em;
+}
+
+@media (max-width: 1023px) {
+  .liquid-glass-badge {
+    display: none;
+  }
+}
+
+@keyframes liquid-pip-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(1.12);
+    opacity: 0.75;
+  }
+}
+
 .ring-dynamic {
   --tw-ring-color: var(--dynamic-glass-border);
 }

--- a/assets/js/liquid-glass-gsap.js
+++ b/assets/js/liquid-glass-gsap.js
@@ -1,0 +1,104 @@
+(function () {
+  const createLayers = (panel) => {
+    const existingLayers = panel.querySelectorAll('.liquid-glass-layer');
+    if (existingLayers.length === 3) {
+      return Array.from(existingLayers);
+    }
+
+    const fragment = document.createDocumentFragment();
+    const layers = [
+      { className: 'liquid-glass-layer liquid-glass-layer--base' },
+      { className: 'liquid-glass-layer liquid-glass-layer--cyan' },
+      { className: 'liquid-glass-layer liquid-glass-layer--magenta' },
+    ].map((layerConfig) => {
+      const element = document.createElement('span');
+      element.className = layerConfig.className;
+      fragment.appendChild(element);
+      return element;
+    });
+
+    panel.appendChild(fragment);
+
+    return layers;
+  };
+
+  const animateLayers = (layers) => {
+    if (!layers.length || !window.gsap) return;
+
+    layers.forEach((layer, index) => {
+      window.gsap.set(layer, {
+        xPercent: window.gsap.utils.random(-10, 10, true),
+        yPercent: window.gsap.utils.random(-10, 10, true),
+        rotation: window.gsap.utils.random(-6, 6, true),
+      });
+
+      const floatRange = 12 + index * 6;
+      const rotateRange = 8 + index * 4;
+      const duration = 12 + index * 4;
+
+      window.gsap.to(layer, {
+        xPercent: window.gsap.utils.random(-floatRange, floatRange, true),
+        yPercent: window.gsap.utils.random(-floatRange, floatRange, true),
+        rotation: window.gsap.utils.random(-rotateRange, rotateRange, true),
+        duration,
+        ease: 'sine.inOut',
+        repeat: -1,
+        yoyo: true,
+      });
+    });
+  };
+
+  const animateBadge = (badge) => {
+    if (!badge || !window.gsap) return;
+
+    const shimmer = badge.querySelector('.liquid-glass-badge__shimmer');
+
+    if (shimmer) {
+      window.gsap.to(shimmer, {
+        rotation: 360,
+        duration: 24,
+        ease: 'none',
+        repeat: -1,
+      });
+    }
+
+    window.gsap.to(badge, {
+      duration: 6,
+      ease: 'sine.inOut',
+      repeat: -1,
+      yoyo: true,
+      scale: 1.04,
+      rotate: 2,
+      transformOrigin: '50% 50%',
+    });
+  };
+
+  const animateStatus = (pip) => {
+    if (!pip || !window.gsap) return;
+
+    window.gsap.to(pip, {
+      scale: 1.12,
+      opacity: 0.85,
+      duration: 2.6,
+      repeat: -1,
+      yoyo: true,
+      ease: 'sine.inOut',
+    });
+  };
+
+  document.addEventListener('DOMContentLoaded', () => {
+    if (!window.gsap) return;
+
+    const panel = document.querySelector('[data-liquid-glass-panel]');
+    if (!panel) return;
+
+    const layers = createLayers(panel);
+    animateLayers(layers);
+
+    const badge = panel.querySelector('[data-liquid-glass]');
+    animateBadge(badge);
+
+    const pip = panel.querySelector('.liquid-glass-pip');
+    animateStatus(pip);
+  });
+})();


### PR DESCRIPTION
## Summary
- load GSAP globally and initialize a new liquid glass animation script
- enhance the hero contact panel markup with an animated status badge and responsive badge fallback
- add supporting styles and motion logic to deliver the liquid glass effect on the panel layers

## Testing
- bundle exec jekyll serve --host 0.0.0.0 --port 4000

------
https://chatgpt.com/codex/tasks/task_e_68dd3825c8708324b0a1423b20adf712