### PR TITLE
Refine gradient background and navigation behavior

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -179,6 +179,7 @@
 
       const applyGradient = () => {
         const { gradient, top, bottom } = getGradientForTime(new Date());
+        document.documentElement.style.setProperty('--sky-gradient', gradient);
         document.body.style.setProperty('--sky-gradient', gradient);
         applyDynamicPalette(top, bottom);
       };

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -38,15 +38,36 @@ html.has-mobile-nav {
   overflow: hidden;
 }
 
-body {
-  background: #030712;
+html {
+  min-height: 100%;
+  background-color: #030712;
   background-image: var(--sky-gradient);
   background-attachment: fixed;
   background-repeat: no-repeat;
-  background-size: cover;
-  background-position: center top;
+  background-size: 100% calc(100% + 40vh);
+  background-position: center calc(-20vh);
+  transition: background-image 1s ease;
+}
+
+body {
+  position: relative;
+  background: transparent;
   color: var(--dynamic-text-on-background);
-  transition: background-image 1s ease, color 0.6s ease;
+  transition: color 0.6s ease;
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: -30vh 0 -20vh;
+  background-image: var(--sky-gradient);
+  background-repeat: no-repeat;
+  background-size: 100% calc(100% + 50vh);
+  background-position: center top;
+  pointer-events: none;
+  z-index: -2;
+  transform: translateZ(0);
+  transition: background-image 1s ease;
 }
 
 .text-dynamic {
@@ -73,8 +94,6 @@ body {
   background: var(--dynamic-glass-background);
   border-color: var(--dynamic-glass-border);
   color: var(--dynamic-glass-text);
-  backdrop-filter: blur(24px);
-  -webkit-backdrop-filter: blur(24px);
   transition: background-color 0.6s ease, border-color 0.6s ease, color 0.6s ease, box-shadow 0.6s ease;
 }
 
@@ -83,7 +102,7 @@ body {
 }
 
 .site-header {
-  position: fixed;
+  position: relative;
   top: 0;
   left: 0;
   width: 100%;
@@ -92,7 +111,6 @@ body {
   justify-content: center;
   padding: 0 var(--header-padding-x);
   transition: transform 0.4s ease, opacity 0.4s ease;
-  isolation: isolate;
   --header-edge: clamp(
     var(--header-padding-x),
     calc((100vw - var(--header-max-width)) / 2 + var(--header-padding-x)),
@@ -103,25 +121,7 @@ body {
 }
 
 .site-header::before {
-  content: '';
-  position: absolute;
-  top: -20px;
-  left: 0;
-  right: 0;
-  height: calc(var(--header-height) + 40px);
-  background: linear-gradient(
-    180deg,
-    rgba(15, 23, 42, 0.6) 0%,
-    rgba(15, 23, 42, 0.35) 35%,
-    rgba(15, 23, 42, 0.08) 70%,
-    rgba(15, 23, 42, 0) 100%
-  );
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
-  -webkit-mask-image: linear-gradient(180deg, rgba(255, 255, 255, 1), rgba(255, 255, 255, 0));
-  mask-image: linear-gradient(180deg, rgba(255, 255, 255, 1), rgba(255, 255, 255, 0));
-  pointer-events: none;
-  z-index: -1;
+  content: none;
 }
 
 .site-header[data-collapsed='true'] {
@@ -138,7 +138,6 @@ body {
   padding: 1.5rem 0;
   min-height: var(--header-height);
   transition: padding 0.3s ease;
-  pointer-events: none;
 }
 
 .site-header[data-collapsed='true'] .site-header__bar {
@@ -146,18 +145,15 @@ body {
 }
 
 .site-header__brand {
-  position: fixed;
-  top: var(--header-brand-top);
-  left: var(--header-edge);
-  z-index: 70;
+  position: relative;
+  z-index: auto;
   font-size: 1.05rem;
   font-weight: 600;
   letter-spacing: -0.01em;
   color: var(--dynamic-text-on-background);
   text-decoration: none;
-  pointer-events: auto;
   text-shadow: 0 8px 24px rgba(15, 23, 42, 0.55);
-  transition: color 0.3s ease, top 0.3s ease;
+  transition: color 0.3s ease;
 }
 
 .site-nav {
@@ -167,6 +163,7 @@ body {
   z-index: 70;
   display: flex;
   align-items: center;
+  justify-content: flex-end;
   gap: 1rem;
   pointer-events: auto;
   transition: top 0.3s ease;
@@ -223,10 +220,8 @@ body {
   padding: 1.5rem;
   margin: 0;
   border-radius: 1.5rem;
-  background: linear-gradient(180deg, rgba(15, 23, 42, 0.76), rgba(15, 23, 42, 0.55));
-  box-shadow: 0 28px 60px -35px rgba(15, 23, 42, 0.6), inset 0 1px 0 rgba(255, 255, 255, 0.18);
-  backdrop-filter: blur(24px) saturate(140%);
-  -webkit-backdrop-filter: blur(24px) saturate(140%);
+  background: rgba(15, 23, 42, 0.92);
+  box-shadow: 0 28px 60px -35px rgba(15, 23, 42, 0.6), inset 0 1px 0 rgba(255, 255, 255, 0.1);
   opacity: 0;
   visibility: hidden;
   transform: translateY(-14px) scale(0.98);
@@ -247,7 +242,7 @@ body {
 .site-nav__overlay {
   position: fixed;
   inset: 0;
-  background: radial-gradient(circle at top, rgba(15, 23, 42, 0.45), rgba(2, 6, 23, 0.72));
+  background: rgba(2, 6, 23, 0.6);
   opacity: 0;
   visibility: hidden;
   transition: opacity 0.4s ease, visibility 0.4s ease;
@@ -301,10 +296,8 @@ body {
     padding: 0.45rem 0.65rem;
     margin: 0;
     border-radius: 9999px;
-    background: transparent;
-    box-shadow: none;
-    backdrop-filter: none;
-    -webkit-backdrop-filter: none;
+    background: rgba(15, 23, 42, 0.82);
+    box-shadow: 0 18px 36px -24px rgba(15, 23, 42, 0.9), inset 0 1px 0 rgba(255, 255, 255, 0.16);
     opacity: 1;
     visibility: visible;
     transform: translateY(0) scale(1);
@@ -315,17 +308,7 @@ body {
   }
 
   .site-nav__list::before {
-    content: '';
-    position: absolute;
-    inset: 0;
-    border-radius: inherit;
-    background: linear-gradient(140deg, rgba(255, 255, 255, 0.32), rgba(148, 163, 184, 0.12));
-    border: 1px solid rgba(255, 255, 255, 0.22);
-    box-shadow: 0 18px 36px -24px rgba(15, 23, 42, 0.9), inset 0 1px 0 rgba(255, 255, 255, 0.25);
-    backdrop-filter: blur(24px);
-    -webkit-backdrop-filter: blur(24px);
-    opacity: 0.95;
-    z-index: -1;
+    content: none;
   }
 
   .site-nav[data-collapsed='true'] .site-nav__list {
@@ -391,8 +374,8 @@ body {
   }
 
   .site-nav__overlay {
-    backdrop-filter: blur(14px);
-    -webkit-backdrop-filter: blur(14px);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- extend the dynamic background gradient coverage to the html element and a fixed body overlay so it remains visible beyond the viewport edges
- remove blur overlays, keep the brand link in the page flow, and align the fixed navigation controls for the collapse behavior
- update the gradient script to apply CSS variables on the root element for consistent styling across browsers

## Testing
- bundle exec jekyll serve --livereload --port 4000 --host 0.0.0.0


------
https://chatgpt.com/codex/tasks/task_e_68dd3a7c55248324918aae8e81d7f160