### PR TITLE
Keep desktop nav expanded and remove phone contact

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -206,6 +206,8 @@
       const navOverlay = nav?.querySelector('[data-nav-overlay]');
       const navLinks = nav?.querySelectorAll('.site-nav__link');
       const root = document.documentElement;
+      const isDesktop = () => window.matchMedia('(min-width: 768px)').matches;
+
       const setMobileOpen = (state) => {
         if (!navToggle) return;
         nav?.setAttribute('data-mobile-open', state.toString());
@@ -214,9 +216,11 @@
       };
 
       const setNavCollapsed = (state) => {
-        nav?.setAttribute('data-collapsed', state.toString());
-        header?.setAttribute('data-collapsed', state.toString());
-        if (state) {
+        const shouldForceExpanded = isDesktop();
+        const finalState = shouldForceExpanded ? false : state;
+        nav?.setAttribute('data-collapsed', finalState.toString());
+        header?.setAttribute('data-collapsed', finalState.toString());
+        if (finalState) {
           setMobileOpen(false);
         }
       };
@@ -226,19 +230,13 @@
 
       const handleScroll = () => {
         const currentY = window.scrollY;
-        const isDesktop = window.matchMedia('(min-width: 768px)').matches;
-
-        if (!isDesktop) {
+        if (!isDesktop()) {
           setNavCollapsed(true);
           lastScrollY = currentY;
           return;
         }
 
-        if (currentY > lastScrollY + 12 && currentY > 120) {
-          setNavCollapsed(true);
-        } else if (currentY < lastScrollY - 12 || currentY <= 80) {
-          setNavCollapsed(false);
-        }
+        setNavCollapsed(false);
 
         lastScrollY = currentY;
       };
@@ -254,13 +252,8 @@
       });
 
       const handleResize = () => {
-        const isDesktop = window.matchMedia('(min-width: 768px)').matches;
-        if (isDesktop) {
-          if (window.scrollY <= 80) {
-            setNavCollapsed(false);
-          } else {
-            handleScroll();
-          }
+        if (isDesktop()) {
+          setNavCollapsed(false);
         } else {
           setNavCollapsed(true);
         }
@@ -271,8 +264,7 @@
       handleResize();
 
       navToggle?.addEventListener('click', () => {
-        const isDesktop = window.matchMedia('(min-width: 768px)').matches;
-        if (isDesktop) {
+        if (isDesktop()) {
           setNavCollapsed(false);
           return;
         }

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -50,10 +50,6 @@ layout: default
             <p class="text-on-glass mt-1 text-base font-medium">{{ site.contact.location }}</p>
           </li>
           <li class="glass-dynamic rounded-2xl border p-4 shadow-sm">
-            <p class="text-on-glass-muted text-xs font-semibold uppercase tracking-wide">Phone</p>
-            <a class="text-on-glass mt-1 inline-flex text-base font-medium hover:text-brand" href="tel:{{ site.contact.phone | replace: ' ', '' }}">{{ site.contact.phone }}</a>
-          </li>
-          <li class="glass-dynamic rounded-2xl border p-4 shadow-sm">
             <p class="text-on-glass-muted text-xs font-semibold uppercase tracking-wide">Email</p>
             <a class="text-on-glass mt-1 inline-flex text-base font-medium hover:text-brand" href="mailto:{{ site.contact.email }}">{{ site.contact.email }}</a>
           </li>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -247,9 +247,10 @@ body::before {
 .site-header__brand {
   position: relative;
   z-index: auto;
-  font-size: 1.05rem;
-  font-weight: 600;
-  letter-spacing: -0.01em;
+  font-size: 1.6rem;
+  font-weight: 700;
+  letter-spacing: -0.015em;
+  line-height: 1.1;
   color: var(--dynamic-text-on-background);
   text-decoration: none;
   text-shadow: 0 8px 24px rgba(15, 23, 42, 0.55);
@@ -403,6 +404,13 @@ body::before {
 }
 
 @media (min-width: 768px) {
+  .site-nav {
+    position: relative;
+    top: auto;
+    right: auto;
+    align-self: center;
+  }
+
   .site-nav__list {
     position: relative;
     top: auto;


### PR DESCRIPTION
## Summary
- prevent the desktop navigation from collapsing by forcing the header to remain expanded while keeping the mobile drawer behaviour intact
- enlarge the Liam Day brand text and reposition the desktop navigation so the header elements align cleanly at the top of the page
- remove the published phone number from the home page contact list

## Testing
- npm run build *(fails: Missing script "build")*

------
https://chatgpt.com/codex/tasks/task_e_68dd5bf855148324b72d756538cae992