### PR TITLE
Implement time-aware dynamic background palette

### DIFF
--- a/_data/background.yml
+++ b/_data/background.yml
@@ -1,3 +1,34 @@
 color: "#030712"
 label: "Midnight canvas"
 description: "Primary background colour applied across the site."
+time_ranges:
+  - label: "Night watch"
+    start_hour: 0
+    end_hour: 5
+    gradient:
+      top: "#020617"
+      bottom: "#0b1120"
+  - label: "First light"
+    start_hour: 5
+    end_hour: 8
+    gradient:
+      top: "#0f172a"
+      bottom: "#1d4ed8"
+  - label: "Daybreak blue"
+    start_hour: 8
+    end_hour: 17
+    gradient:
+      top: "#eff6ff"
+      bottom: "#60a5fa"
+  - label: "Golden hour"
+    start_hour: 17
+    end_hour: 20
+    gradient:
+      top: "#172554"
+      bottom: "#f97316"
+  - label: "Evening hush"
+    start_hour: 20
+    end_hour: 24
+    gradient:
+      top: "#030712"
+      bottom: "#0b1120"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -70,7 +70,14 @@
     <script src="{{ '/assets/js/liquid-glass-gsap.js' | relative_url }}"></script>
     <script src="{{ '/assets/js/liquid-glass-nav.js' | relative_url }}"></script>
     <script>
-      const baseBackgroundHex = '{{ site.data.background.color | default: "#030712" }}';
+      const backgroundData = {{ site.data.background | jsonify | replace: '</', '<\/' }};
+
+      const FALLBACK_BACKGROUND_HEX = (() => {
+        if (backgroundData && typeof backgroundData.color === 'string' && backgroundData.color.trim()) {
+          return backgroundData.color;
+        }
+        return '#030712';
+      })();
 
       const hexToRgb = (hex) => {
         if (typeof hex !== 'string') {
@@ -161,6 +168,127 @@
         const { r, g, b } = color;
         return `${r}, ${g}, ${b}`;
       };
+
+      const componentToHex = (value) => {
+        const clamped = Math.max(0, Math.min(255, Math.round(value)));
+        return clamped.toString(16).padStart(2, '0');
+      };
+
+      const rgbToHex = (color) => {
+        if (!color) {
+          return '';
+        }
+        return `#${componentToHex(color.r)}${componentToHex(color.g)}${componentToHex(color.b)}`;
+      };
+
+      const normalizeHex = (hex) => {
+        const color = hexToRgb(hex);
+        return color ? rgbToHex(color) : null;
+      };
+
+      const buildBackgroundConfig = (entry, fallbackLabel) => {
+        if (!entry || typeof entry !== 'object') {
+          return null;
+        }
+
+        const gradient = entry.gradient && typeof entry.gradient === 'object' ? entry.gradient : {};
+        const top =
+          (typeof gradient.top === 'string' && gradient.top.trim()) ||
+          (typeof entry.top === 'string' && entry.top.trim()) ||
+          (typeof entry.color === 'string' && entry.color.trim()) ||
+          null;
+        const bottom =
+          (typeof gradient.bottom === 'string' && gradient.bottom.trim()) ||
+          (typeof entry.bottom === 'string' && entry.bottom.trim()) ||
+          (typeof entry.color === 'string' && entry.color.trim()) ||
+          top;
+        const label =
+          (typeof entry.label === 'string' && entry.label.trim()) ||
+          (typeof fallbackLabel === 'string' && fallbackLabel.trim()) ||
+          '';
+
+        return { top, bottom, label };
+      };
+
+      const mapTimeRanges = () => {
+        if (!backgroundData || !Array.isArray(backgroundData.time_ranges)) {
+          return [];
+        }
+
+        return backgroundData.time_ranges
+          .map((range) => {
+            if (!range || typeof range !== 'object') {
+              return null;
+            }
+
+            const config = buildBackgroundConfig(range, backgroundData.label);
+            if (!config) {
+              return null;
+            }
+
+            const startHour = typeof range.start_hour === 'number' ? range.start_hour : null;
+            const endHour = typeof range.end_hour === 'number' ? range.end_hour : null;
+
+            return { ...config, startHour, endHour };
+          })
+          .filter(Boolean);
+      };
+
+      const getDefaultBackground = () => {
+        const fallback = buildBackgroundConfig(backgroundData?.default || backgroundData, backgroundData?.label);
+        if (fallback && fallback.top) {
+          fallback.bottom = fallback.bottom || fallback.top;
+          return fallback;
+        }
+
+        return { top: FALLBACK_BACKGROUND_HEX, bottom: FALLBACK_BACKGROUND_HEX, label: backgroundData?.label || '' };
+      };
+
+      const resolveActiveTimeRange = () => {
+        const ranges = mapTimeRanges();
+        if (!ranges.length) {
+          return null;
+        }
+
+        const now = new Date();
+        const currentHour = now.getHours() + now.getMinutes() / 60 + now.getSeconds() / 3600;
+
+        for (const range of ranges) {
+          if (typeof range.startHour !== 'number' || typeof range.endHour !== 'number') {
+            continue;
+          }
+
+          const start = Math.max(0, Math.min(24, range.startHour));
+          const rawEnd = Math.max(0, Math.min(24, range.endHour));
+          const end = rawEnd === 0 && range.endHour !== 0 ? 24 : rawEnd;
+
+          if (start <= end) {
+            if (currentHour >= start && currentHour < end) {
+              return range;
+            }
+          } else {
+            if (currentHour >= start || currentHour < end) {
+              return range;
+            }
+          }
+        }
+
+        return ranges[0];
+      };
+
+      const getActiveBackground = () => {
+        const activeRange = resolveActiveTimeRange();
+        if (activeRange) {
+          const { startHour, endHour, ...config } = activeRange;
+          return config;
+        }
+
+        return getDefaultBackground();
+      };
+
+      const fallbackHexNormalized = normalizeHex(FALLBACK_BACKGROUND_HEX) || '#030712';
+      const fallbackColor = hexToRgb(fallbackHexNormalized) || { r: 3, g: 7, b: 18 };
+      const BACKGROUND_UPDATE_INTERVAL = 5 * 60 * 1000;
 
       const rgbToHsl = (color) => {
         if (!color) {
@@ -329,27 +457,44 @@
       };
 
       const applyBackground = () => {
-        const baseColor = hexToRgb(baseBackgroundHex);
-        if (!baseColor) {
-          return;
-        }
+        const activeBackground = getActiveBackground();
+        const topHex = normalizeHex(activeBackground?.top) || fallbackHexNormalized;
+        const bottomHex = normalizeHex(activeBackground?.bottom) || topHex || fallbackHexNormalized;
+
+        const topColor = hexToRgb(topHex) || fallbackColor;
+        const bottomColor = hexToRgb(bottomHex) || topColor || fallbackColor;
+        const baseColor = mixRgb(topColor, bottomColor, 0.5) || topColor || fallbackColor;
+        const baseHex = rgbToHex(baseColor) || fallbackHexNormalized;
 
         const rootElement = document.documentElement;
-        const rgbString = `${baseColor.r}, ${baseColor.g}, ${baseColor.b}`;
+        rootElement.style.setProperty('--sky-background-color', baseHex);
+        rootElement.style.setProperty('--sky-background-rgb', rgbValuesToString(baseColor));
+        rootElement.style.setProperty('--sky-gradient-top', topHex);
+        rootElement.style.setProperty('--sky-gradient-bottom', bottomHex);
+        rootElement.style.backgroundColor = baseHex;
 
-        rootElement.style.setProperty('--sky-background-color', baseBackgroundHex);
-        rootElement.style.setProperty('--sky-background-rgb', rgbString);
-        rootElement.style.backgroundColor = baseBackgroundHex;
+        if (topHex && bottomHex && topHex !== bottomHex) {
+          rootElement.style.backgroundImage = `linear-gradient(180deg, ${topHex}, ${bottomHex})`;
+        } else {
+          rootElement.style.backgroundImage = 'none';
+        }
+
+        if (activeBackground?.label) {
+          rootElement.setAttribute('data-sky-label', activeBackground.label);
+        } else {
+          rootElement.removeAttribute('data-sky-label');
+        }
 
         const themeColorMeta = document.querySelector('meta[name="theme-color"]');
         if (themeColorMeta) {
-          themeColorMeta.setAttribute('content', baseBackgroundHex);
+          themeColorMeta.setAttribute('content', baseHex);
         }
 
-        applyDynamicPalette(baseColor, baseColor);
+        applyDynamicPalette(topColor, bottomColor);
       };
 
       applyBackground();
+      window.setInterval(applyBackground, BACKGROUND_UPDATE_INTERVAL);
 
       const header = document.querySelector('[data-site-header]');
       const nav = document.querySelector('[data-nav]');

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -56,7 +56,9 @@ html.has-mobile-nav {
 html {
   min-height: 100%;
   background-color: var(--sky-background-color, #030712);
-  transition: background-color 0.6s ease;
+  background-image: none;
+  background-repeat: no-repeat;
+  transition: background-color 0.6s ease, background-image 0.6s ease;
 }
 
 body {

--- a/style-guide.md
+++ b/style-guide.md
@@ -76,9 +76,10 @@ permalink: /style-guide/
     <div class="space-y-4">
       <h2 class="text-dynamic text-2xl font-semibold">Colour system</h2>
       <p class="text-dynamic-muted text-base leading-relaxed">
-        The site now anchors to a single atmospheric backdrop defined in
+        The site’s sky backdrop is orchestrated from
         <code class="rounded bg-slate-900/10 px-1.5 py-0.5 text-sm text-slate-900">_data/background.yml</code>.
-        Updating that file keeps the production background, this style guide, and dependent scripts fully in sync.
+        Each visitor receives a palette that shifts with their local time of day, while the fallback colour keeps feeds and
+        print exports consistent.
       </p>
       <div class="grid gap-3">
         <div class="flex items-center gap-3">
@@ -105,10 +106,7 @@ permalink: /style-guide/
       </div>
     </div>
     <div class="space-y-6">
-      <div
-        class="sg-background-card"
-        style="--sg-background-color: {{ background.color | default: '#030712' }};"
-      >
+      <div class="sg-background-card" style="--sg-background-color: {{ background.color | default: '#030712' }};">
         <div class="sg-background-card__meta">
           <h3 class="text-lg font-semibold text-slate-900">{{ background.label | default: 'Site background' }}</h3>
           <p class="text-sm text-slate-600">{{ background.description | default: 'Primary background colour applied across the site.' }}</p>
@@ -120,7 +118,7 @@ permalink: /style-guide/
             <dd><code>_data/background.yml</code></dd>
           </div>
           <div class="sg-token-list__item">
-            <dt>Hex value</dt>
+            <dt>Fallback hex</dt>
             <dd><code>{{ background.color | default: '#030712' }}</code></dd>
           </div>
           <div class="sg-token-list__item">
@@ -133,16 +131,57 @@ permalink: /style-guide/
           </div>
         </dl>
       </div>
+      {% if background.time_ranges %}
+      <div class="rounded-3xl border border-slate-200 bg-white/70 p-6 shadow-sm backdrop-blur">
+        <h3 class="text-base font-semibold text-slate-900">Time-aware sky gradients</h3>
+        <p class="mt-2 text-sm text-slate-600">
+          These ranges animate automatically in the browser, ensuring cards and navigation pick light or dark treatments that
+          match the current sky.
+        </p>
+        <div class="mt-5 grid gap-4 lg:grid-cols-2">
+          {% for range in background.time_ranges %}
+          {% assign start_hour = range.start_hour | default: 0 %}
+          {% assign end_hour = range.end_hour | default: 0 %}
+          {% assign start_display = '%02d' | format: start_hour %}
+          {% if end_hour == 24 %}
+          {% assign end_display = '00' %}
+          {% else %}
+          {% assign end_display = '%02d' | format: end_hour %}
+          {% endif %}
+          {% assign top_color = range.gradient.top | default: range.top | default: range.color | default: background.color %}
+          {% assign bottom_color = range.gradient.bottom | default: range.bottom | default: range.color | default: top_color %}
+          <div class="flex flex-col gap-3 rounded-2xl border border-slate-200 bg-white/80 p-4 shadow-sm backdrop-blur">
+            <div class="flex flex-wrap items-center justify-between gap-3">
+              <p class="text-sm font-semibold uppercase tracking-[0.25em] text-slate-500">{{ range.label }}</p>
+              <p class="font-mono text-xs text-slate-500">{{ start_display }}:00 – {{ end_display }}:00</p>
+            </div>
+            <div
+              class="h-12 w-full rounded-xl border border-slate-200"
+              style="background: linear-gradient(135deg, {{ top_color }}, {{ bottom_color }});"
+            ></div>
+          </div>
+          {% endfor %}
+        </div>
+      </div>
+      {% endif %}
       <div class="rounded-3xl border border-slate-200 bg-white/70 p-6 shadow-sm backdrop-blur">
         <h3 class="text-base font-semibold text-slate-900">Dynamic CSS variables</h3>
         <dl class="mt-4 grid gap-4 text-sm text-slate-600 sm:grid-cols-2">
           <div>
             <dt class="font-semibold text-slate-900">--sky-background-color</dt>
-            <dd>Static backdrop shared between the site and documentation. Update via <code class="font-mono text-xs text-slate-500">_data/background.yml</code>.</dd>
+            <dd>Current sky midpoint applied to the document root and theme colour meta tag.</dd>
           </div>
           <div>
             <dt class="font-semibold text-slate-900">--sky-background-rgb</dt>
             <dd>Pre-calculated RGB channel values for WebGL and canvas effects.</dd>
+          </div>
+          <div>
+            <dt class="font-semibold text-slate-900">--sky-gradient-top</dt>
+            <dd>Active gradient start colour mirrored from the current sky preset.</dd>
+          </div>
+          <div>
+            <dt class="font-semibold text-slate-900">--sky-gradient-bottom</dt>
+            <dd>Active gradient end colour that complements navigation and card treatments.</dd>
           </div>
           <div>
             <dt class="font-semibold text-slate-900">--dynamic-text-on-background</dt>
@@ -150,7 +189,7 @@ permalink: /style-guide/
           </div>
           <div>
             <dt class="font-semibold text-slate-900">--dynamic-glass-background</dt>
-            <dd>Controls glassmorphism surfaces, ensuring cards stay legible against the midnight base.</dd>
+            <dd>Controls glassmorphism surfaces, ensuring cards stay legible whether the sky is bright or midnight dark.</dd>
           </div>
           <div>
             <dt class="font-semibold text-slate-900">--dynamic-control-surface</dt>


### PR DESCRIPTION
## Summary
- add time-of-day gradient presets to the background data source
- compute the active sky palette on the client and update glass, navigation, and accent tokens
- expose gradient variables in CSS and document the new time-aware system in the style guide

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de55a846308324ba1f40eed36e1ab0