### PR TITLE
Use solid time-based background colours

### DIFF
--- a/_data/background.yml
+++ b/_data/background.yml
@@ -5,30 +5,20 @@ time_ranges:
   - label: "Night watch"
     start_hour: 0
     end_hour: 5
-    gradient:
-      top: "#020617"
-      bottom: "#0b1120"
+    color: "#070c1c"
   - label: "First light"
     start_hour: 5
     end_hour: 8
-    gradient:
-      top: "#0f172a"
-      bottom: "#1d4ed8"
+    color: "#163381"
   - label: "Daybreak blue"
     start_hour: 8
     end_hour: 17
-    gradient:
-      top: "#eff6ff"
-      bottom: "#60a5fa"
+    color: "#a8cefd"
   - label: "Golden hour"
     start_hour: 17
     end_hour: 20
-    gradient:
-      top: "#172554"
-      bottom: "#f97316"
+    color: "#884c35"
   - label: "Evening hush"
     start_hour: 20
     end_hour: 24
-    gradient:
-      top: "#030712"
-      bottom: "#0b1120"
+    color: "#070c19"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,7 +3,7 @@
   <head>
     {% include head.html %}
   </head>
-  <body class="flex min-h-screen flex-col font-sans text-slate-900">
+  <body class="flex min-h-screen flex-col font-sans">
     <a
       class="sr-only focus:not-sr-only focus:absolute focus:left-6 focus:top-6 focus:rounded-full focus:bg-brand focus:px-4 focus:py-2 focus:text-white focus:shadow-lg"
       href="#main"
@@ -41,22 +41,22 @@
       {{ content }}
     </main>
 
-    <footer class="border-t border-slate-200 py-12">
-      <div class="mx-auto flex w-full max-w-6xl flex-col gap-8 px-6 text-sm text-slate-600 sm:text-base lg:flex-row lg:items-start lg:justify-between">
+    <footer class="border-t border-dynamic py-12">
+      <div class="mx-auto flex w-full max-w-6xl flex-col gap-8 px-6 text-sm text-dynamic-muted sm:text-base lg:flex-row lg:items-start lg:justify-between">
         <div class="space-y-3">
-          <p class="text-lg font-semibold text-slate-900">Let’s collaborate.</p>
+          <p class="text-lg font-semibold text-dynamic">Let’s collaborate.</p>
           <a class="inline-flex items-center gap-2 text-brand-dark hover:text-brand" href="mailto:{{ site.social.email }}">
             <span>{{ site.social.email }}</span>
           </a>
         </div>
         <div class="flex flex-1 flex-col gap-4 sm:flex-row sm:items-end sm:justify-end">
-          <ul class="flex flex-wrap gap-4 text-sm font-medium text-slate-600" aria-label="Social links">
+          <ul class="flex flex-wrap gap-4 text-sm font-medium text-dynamic-muted" aria-label="Social links">
             {% if site.social.linkedin %}<li><a class="hover:text-brand" href="{{ site.social.linkedin }}">LinkedIn</a></li>{% endif %}
             {% if site.social.dribbble %}<li><a class="hover:text-brand" href="{{ site.social.dribbble }}">Dribbble</a></li>{% endif %}
             {% if site.social.github %}<li><a class="hover:text-brand" href="{{ site.social.github }}">GitHub</a></li>{% endif %}
             {% if site.social.medium %}<li><a class="hover:text-brand" href="{{ site.social.medium }}">Medium</a></li>{% endif %}
           </ul>
-          <p class="text-xs text-slate-400 sm:text-right">© {{ "now" | date: "%Y" }} {{ site.title }} · Built with Jekyll.</p>
+          <p class="text-xs text-dynamic-muted sm:text-right">© {{ "now" | date: "%Y" }} {{ site.title }} · Built with Jekyll.</p>
         </div>
       </div>
     </footer>
@@ -152,6 +152,24 @@
       const mixWith = (color, target, factor) => mixRgb(color, target, factor);
       const lighten = (color, factor = 0.5) => mixWith(color, WHITE, factor);
       const darken = (color, factor = 0.5) => mixWith(color, BLACK, factor);
+
+      const getReadableTextOn = (background) => {
+        if (!background) {
+          return WHITE;
+        }
+
+        const luminance = getRelativeLuminance(background);
+
+        if (luminance >= 0.75) {
+          return darken(background, 0.85);
+        }
+
+        if (luminance <= 0.25) {
+          return lighten(background, 0.85);
+        }
+
+        return luminance > 0.5 ? darken(background, 0.7) : lighten(background, 0.7);
+      };
 
       const rgbaToString = (color, alpha = 1) => {
         if (!color) {
@@ -402,6 +420,12 @@
         const textPrimaryTint = isDarkBackground ? lighten(midpoint, 0.98) : darken(midpoint, 0.92);
         const textMutedTint = isDarkBackground ? lighten(midpoint, 0.9) : darken(midpoint, 0.82);
 
+        const cardBackgroundTint = isDarkBackground ? lighten(midpoint, 0.92) : darken(midpoint, 0.68);
+        const cardBorderTint = isDarkBackground ? lighten(midpoint, 0.82) : darken(midpoint, 0.58);
+        const cardShadowTint = darken(midpoint, isDarkBackground ? 0.88 : 0.54);
+        const cardTextTint = getReadableTextOn(cardBackgroundTint);
+        const cardTextMutedTint = mixRgb(cardTextTint, cardBackgroundTint, 0.45);
+
         const glassBackgroundAlpha = isDarkBackground ? 0.78 : 0.62;
         const controlSurfaceAlpha = isDarkBackground ? 0.42 : 0.26;
         const controlSurfaceHoverAlpha = isDarkBackground ? 0.48 : 0.34;
@@ -421,6 +445,11 @@
           '--dynamic-glass-border': rgbaToString(glassBorderTint, isDarkBackground ? 0.5 : 0.42),
           '--dynamic-glass-text': rgbToString(glassTextTint),
           '--dynamic-glass-text-muted': rgbaToString(glassTextMutedTint, isDarkBackground ? 0.8 : 0.76),
+          '--dynamic-card-background': rgbToString(cardBackgroundTint),
+          '--dynamic-card-border': rgbaToString(cardBorderTint, isDarkBackground ? 0.3 : 0.36),
+          '--dynamic-card-text': rgbToString(cardTextTint),
+          '--dynamic-card-text-muted': rgbaToString(cardTextMutedTint, 0.82),
+          '--dynamic-card-shadow-rgb': rgbValuesToString(cardShadowTint),
           '--dynamic-control-surface': rgbaToString(controlSurfaceTint, controlSurfaceAlpha),
           '--dynamic-control-surface-hover': rgbaToString(controlSurfaceHoverTint, controlSurfaceHoverAlpha),
           '--dynamic-control-text': rgbToString(controlTextTint),

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -469,15 +469,10 @@
         const rootElement = document.documentElement;
         rootElement.style.setProperty('--sky-background-color', baseHex);
         rootElement.style.setProperty('--sky-background-rgb', rgbValuesToString(baseColor));
-        rootElement.style.setProperty('--sky-gradient-top', topHex);
-        rootElement.style.setProperty('--sky-gradient-bottom', bottomHex);
+        rootElement.style.removeProperty('--sky-gradient-top');
+        rootElement.style.removeProperty('--sky-gradient-bottom');
         rootElement.style.backgroundColor = baseHex;
-
-        if (topHex && bottomHex && topHex !== bottomHex) {
-          rootElement.style.backgroundImage = `linear-gradient(180deg, ${topHex}, ${bottomHex})`;
-        } else {
-          rootElement.style.backgroundImage = 'none';
-        }
+        rootElement.style.backgroundImage = 'none';
 
         if (activeBackground?.label) {
           rootElement.setAttribute('data-sky-label', activeBackground.label);

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -84,17 +84,17 @@ layout: default
   </div>
 </section>
 
-<section class="py-16 text-slate-100" id="competencies">
+<section class="py-16" id="competencies">
   <div class="mx-auto max-w-6xl px-6">
     <div class="max-w-3xl space-y-4">
-      <h2 class="text-2xl font-semibold sm:text-3xl">Key competencies</h2>
-      <p class="text-lg text-slate-200">Core strengths that shape Liam’s approach to product strategy, delivery, and stakeholder leadership.</p>
+      <h2 class="text-dynamic text-2xl font-semibold sm:text-3xl">Key competencies</h2>
+      <p class="text-dynamic-muted text-lg leading-relaxed">Core strengths that shape Liam’s approach to product strategy, delivery, and stakeholder leadership.</p>
     </div>
     <div class="mt-10 grid gap-6 md:grid-cols-2">
       {% for competency in cv.competencies %}
-      <article class="rounded-3xl border border-white/10 bg-white/10 p-6 shadow-soft-xl shadow-black/10 backdrop-blur">
-        <h3 class="text-xl font-semibold text-white">{{ competency.title }}</h3>
-        <p class="mt-3 text-base text-slate-100/90">{{ competency.description }}</p>
+      <article class="glass-dynamic rounded-3xl border p-6 shadow-soft-xl backdrop-blur">
+        <h3 class="text-xl font-semibold text-on-glass">{{ competency.title }}</h3>
+        <p class="mt-3 text-base text-on-glass-muted">{{ competency.description }}</p>
       </article>
       {% endfor %}
     </div>
@@ -107,15 +107,15 @@ layout: default
       <h2 class="text-dynamic text-2xl font-semibold sm:text-3xl">Employment</h2>
       <p class="text-dynamic-muted text-lg">Leadership roles spanning mobile software, large-scale training programmes, and secure communications operations.</p>
     </div>
-    <div class="mt-12 space-y-12 border-l border-slate-200 pl-8">
+    <div class="mt-12 space-y-12 border-l border-dynamic pl-8">
       {% for role in cv.employment %}
       <article class="relative space-y-4">
-        <span class="absolute -left-4 top-2 inline-flex h-7 w-7 items-center justify-center rounded-full bg-white shadow ring-4 ring-slate-50">
+        <span class="absolute -left-4 top-2 inline-flex h-7 w-7 items-center justify-center rounded-full bg-[var(--dynamic-card-background)] shadow ring-4 ring-[rgba(var(--dynamic-card-shadow-rgb, var(--dynamic-shadow-rgb, 15, 23, 42)),0.12)]">
           <span class="h-2 w-2 rounded-full bg-brand"></span>
         </span>
-        <div class="flex flex-wrap items-center gap-x-4 text-sm font-medium text-slate-500">
+        <div class="flex flex-wrap items-center gap-x-4 text-sm font-medium text-dynamic-muted">
           <span>{{ role.period }}</span>
-          <span class="hidden text-slate-400 sm:inline">•</span>
+          <span class="hidden text-dynamic-muted sm:inline">•</span>
           <span>{{ role.location }}</span>
         </div>
         <div class="space-y-3">
@@ -142,16 +142,16 @@ layout: default
     <div class="mt-12 grid gap-6 sm:grid-cols-2">
       {% assign ordered_projects = site.projects | sort: "order" %}
       {% for project in ordered_projects %}
-      <article class="group h-full rounded-3xl border border-slate-200 bg-white p-6 shadow-sm transition-transform duration-200 hover:-translate-y-1 hover:shadow-xl">
+      <article class="card-surface group h-full rounded-3xl border p-6 transition-transform duration-200 hover:-translate-y-1">
         <a class="flex h-full flex-col gap-4" href="{{ project.url | relative_url }}">
-          <h3 class="text-xl font-semibold text-slate-900 group-hover:text-brand">{{ project.title }}</h3>
-          <p class="text-base text-slate-600">{{ project.summary }}</p>
+          <h3 class="text-xl font-semibold text-on-card group-hover:text-brand">{{ project.title }}</h3>
+          <p class="text-base text-on-card-muted">{{ project.summary }}</p>
           <span class="mt-auto inline-flex items-center text-sm font-semibold text-brand">View project →</span>
         </a>
       </article>
       {% endfor %}
       {% if ordered_projects == empty %}
-      <p class="rounded-3xl border border-dashed border-slate-300 bg-white/60 p-6 text-base text-slate-600">
+      <p class="card-surface rounded-3xl border border-dashed p-6 text-base text-on-card-muted">
         Project highlights coming soon. In the meantime, explore Liam’s updates on LinkedIn.
       </p>
       {% endif %}
@@ -166,24 +166,24 @@ layout: default
         <h2 class="text-dynamic text-2xl font-semibold sm:text-3xl">Education &amp; Certifications</h2>
       </div>
       <div class="grid gap-8 md:grid-cols-2">
-        <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h3 class="text-lg font-semibold text-slate-900">Education</h3>
-          <ul class="mt-4 space-y-4 text-base text-slate-600">
+        <div class="card-surface rounded-3xl border p-6">
+          <h3 class="text-lg font-semibold text-on-card">Education</h3>
+          <ul class="mt-4 space-y-4 text-base text-on-card-muted">
             {% for item in cv.education %}
             <li>
-              <p class="font-semibold text-slate-900">{{ item.qualification }}</p>
-              <p class="text-sm text-slate-500">{{ item.institution }} · {{ item.period }}</p>
+              <p class="font-semibold text-on-card">{{ item.qualification }}</p>
+              <p class="text-sm text-on-card-muted">{{ item.institution }} · {{ item.period }}</p>
             </li>
             {% endfor %}
           </ul>
         </div>
-        <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h3 class="text-lg font-semibold text-slate-900">Certifications</h3>
-          <ul class="mt-4 space-y-3 text-base text-slate-600">
+        <div class="card-surface rounded-3xl border p-6">
+          <h3 class="text-lg font-semibold text-on-card">Certifications</h3>
+          <ul class="mt-4 space-y-3 text-base text-on-card-muted">
             {% for certification in cv.certifications %}
             <li class="flex items-start gap-2">
               <span class="mt-2 h-1.5 w-1.5 rounded-full bg-brand"></span>
-              <span>{{ certification }}</span>
+              <span class="text-on-card-muted">{{ certification }}</span>
             </li>
             {% endfor %}
           </ul>
@@ -193,14 +193,14 @@ layout: default
   </div>
 </section>
 
-<section class="py-16 text-slate-100" id="connect">
+<section class="py-16" id="connect">
   <div class="mx-auto max-w-4xl px-6 text-center">
-    <h2 class="text-3xl font-semibold sm:text-4xl">Let’s collaborate</h2>
-    <p class="mx-auto mt-4 max-w-2xl text-lg text-slate-200">
+    <h2 class="text-dynamic text-3xl font-semibold sm:text-4xl">Let’s collaborate</h2>
+    <p class="text-dynamic-muted mx-auto mt-4 max-w-2xl text-lg">
       Whether you need to enhance a mobile product, streamline operations, or lead complex delivery programmes, Liam can help you unlock momentum.
     </p>
     <a
-      class="mt-8 inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-base font-semibold text-slate-900 transition hover:bg-brand hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+      class="mt-8 inline-flex items-center justify-center rounded-full border border-transparent bg-[var(--dynamic-control-surface)] px-6 py-3 text-base font-semibold text-[var(--dynamic-control-text)] shadow-sm transition hover:bg-[var(--dynamic-control-surface-hover)] hover:text-[var(--dynamic-control-text)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand"
       href="mailto:{{ site.contact.email }}"
       >Get in touch</a
     >

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -3,11 +3,11 @@ layout: default
 ---
 <article class="py-16">
   <div class="mx-auto max-w-3xl px-6">
-    <header class="border-b border-slate-200 pb-8">
-      <p class="text-sm font-medium uppercase tracking-wide text-slate-500">{{ page.date | date: "%d %B %Y" }}</p>
-      <h1 class="mt-4 text-3xl font-semibold text-slate-900 sm:text-4xl">{{ page.title }}</h1>
+    <header class="border-b border-dynamic pb-8">
+      <p class="text-dynamic-muted text-sm font-medium uppercase tracking-wide">{{ page.date | date: "%d %B %Y" }}</p>
+      <h1 class="mt-4 text-dynamic text-3xl font-semibold sm:text-4xl">{{ page.title }}</h1>
       {% if page.description %}
-      <p class="mt-3 text-lg text-slate-600">{{ page.description }}</p>
+      <p class="mt-3 text-lg text-dynamic-muted">{{ page.description }}</p>
       {% endif %}
     </header>
     <div class="prose prose-slate mt-8 max-w-none">

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -26,6 +26,11 @@
   --dynamic-glass-border: rgba(248, 250, 252, 0.45);
   --dynamic-glass-text: #0f172a;
   --dynamic-glass-text-muted: rgba(15, 23, 42, 0.72);
+  --dynamic-card-background: rgba(248, 250, 252, 0.95);
+  --dynamic-card-border: rgba(203, 213, 225, 0.62);
+  --dynamic-card-text: #0f172a;
+  --dynamic-card-text-muted: rgba(15, 23, 42, 0.72);
+  --dynamic-card-shadow-rgb: 15, 23, 42;
   --dynamic-control-surface: rgba(255, 255, 255, 0.14);
   --dynamic-control-surface-hover: rgba(255, 255, 255, 0.24);
   --dynamic-control-text: #f8fafc;
@@ -93,6 +98,34 @@ body {
   border-color: var(--dynamic-glass-border);
   color: var(--dynamic-glass-text);
   transition: background-color 0.6s ease, border-color 0.6s ease, color 0.6s ease, box-shadow 0.6s ease;
+}
+
+.card-surface {
+  background: var(--dynamic-card-background);
+  border-color: var(--dynamic-card-border);
+  color: var(--dynamic-card-text);
+  box-shadow: 0 20px 45px rgba(var(--dynamic-card-shadow-rgb, var(--dynamic-shadow-rgb, 15, 23, 42)), 0.14);
+  transition: background-color 0.6s ease, border-color 0.6s ease, color 0.6s ease, box-shadow 0.6s ease;
+}
+
+.card-surface:hover,
+.card-surface:focus-visible {
+  box-shadow: 0 28px 65px rgba(var(--dynamic-card-shadow-rgb, var(--dynamic-shadow-rgb, 15, 23, 42)), 0.2);
+}
+
+.text-on-card {
+  color: var(--dynamic-card-text);
+  transition: color 0.6s ease;
+}
+
+.text-on-card-muted {
+  color: var(--dynamic-card-text-muted);
+  transition: color 0.6s ease;
+}
+
+.border-dynamic {
+  border-color: rgba(var(--dynamic-nav-divider-rgb, 148, 163, 184), 0.28) !important;
+  transition: border-color 0.6s ease;
 }
 
 .glass-panel {

--- a/style-guide.md
+++ b/style-guide.md
@@ -9,10 +9,12 @@ permalink: /style-guide/
     display: grid;
     gap: 1.25rem;
     border-radius: 1.5rem;
-    border: 1px solid rgba(15, 23, 42, 0.12);
-    background: rgba(255, 255, 255, 0.85);
+    border: 1px solid var(--dynamic-card-border, rgba(203, 213, 225, 0.4));
+    background: var(--dynamic-card-background, rgba(248, 250, 252, 0.95));
+    color: var(--dynamic-card-text, #0f172a);
     padding: 1.75rem;
-    box-shadow: 0 20px 40px rgba(15, 23, 42, 0.1);
+    box-shadow: 0 20px 40px rgba(var(--dynamic-card-shadow-rgb, 15, 23, 42), 0.12);
+    transition: background-color 0.6s ease, border-color 0.6s ease, color 0.6s ease, box-shadow 0.6s ease;
   }
 
   .sg-background-card__swatch {
@@ -40,7 +42,7 @@ permalink: /style-guide/
     flex-direction: column;
     gap: 0.25rem;
     font-size: 0.85rem;
-    color: #475569;
+    color: var(--dynamic-card-text-muted, rgba(71, 85, 105, 0.9));
   }
 
   .sg-token-list__item dt {
@@ -48,16 +50,16 @@ permalink: /style-guide/
     font-weight: 600;
     letter-spacing: 0.12em;
     text-transform: uppercase;
-    color: #334155;
+    color: var(--dynamic-card-text, #0f172a);
   }
 
   .sg-token-list__item code {
     font-size: 0.85rem;
     font-weight: 600;
-    background: rgba(15, 23, 42, 0.08);
+    background: rgba(var(--dynamic-card-shadow-rgb, 15, 23, 42), 0.08);
     border-radius: 0.4rem;
     padding: 0.15rem 0.5rem;
-    color: #0f172a;
+    color: var(--dynamic-card-text, #0f172a);
   }
 </style>
 
@@ -108,8 +110,8 @@ permalink: /style-guide/
     <div class="space-y-6">
       <div class="sg-background-card" style="--sg-background-color: {{ background.color | default: '#030712' }};">
         <div class="sg-background-card__meta">
-          <h3 class="text-lg font-semibold text-slate-900">{{ background.label | default: 'Site background' }}</h3>
-          <p class="text-sm text-slate-600">{{ background.description | default: 'Primary background colour applied across the site.' }}</p>
+          <h3 class="text-lg font-semibold text-on-card">{{ background.label | default: 'Site background' }}</h3>
+          <p class="text-sm text-on-card-muted">{{ background.description | default: 'Primary background colour applied across the site.' }}</p>
         </div>
         <div class="sg-background-card__swatch" aria-hidden="true"></div>
         <dl class="sg-token-list">
@@ -132,9 +134,9 @@ permalink: /style-guide/
         </dl>
       </div>
       {% if background.time_ranges %}
-      <div class="rounded-3xl border border-slate-200 bg-white/70 p-6 shadow-sm backdrop-blur">
-        <h3 class="text-base font-semibold text-slate-900">Time-aware sky colours</h3>
-        <p class="mt-2 text-sm text-slate-600">
+      <div class="card-surface rounded-3xl border p-6 backdrop-blur">
+        <h3 class="text-base font-semibold text-on-card">Time-aware sky colours</h3>
+        <p class="mt-2 text-sm text-on-card-muted">
           These ranges animate automatically in the browser, ensuring cards and navigation pick light or dark treatments that
           match the current sky tone.
         </p>
@@ -149,13 +151,13 @@ permalink: /style-guide/
           {% assign end_display = '%02d' | format: end_hour %}
           {% endif %}
           {% assign solid_color = range.color | default: range.top | default: background.color %}
-          <div class="flex flex-col gap-3 rounded-2xl border border-slate-200 bg-white/80 p-4 shadow-sm backdrop-blur">
+          <div class="card-surface rounded-2xl border p-4 backdrop-blur">
             <div class="flex flex-wrap items-center justify-between gap-3">
-              <p class="text-sm font-semibold uppercase tracking-[0.25em] text-slate-500">{{ range.label }}</p>
-              <p class="font-mono text-xs text-slate-500">{{ start_display }}:00 – {{ end_display }}:00</p>
+              <p class="text-sm font-semibold uppercase tracking-[0.25em] text-on-card-muted">{{ range.label }}</p>
+              <p class="font-mono text-xs text-on-card-muted">{{ start_display }}:00 – {{ end_display }}:00</p>
             </div>
             <div
-              class="h-12 w-full rounded-xl border border-slate-200"
+              class="h-12 w-full rounded-xl border border-dynamic"
               style="background: {{ solid_color }};"
             ></div>
           </div>
@@ -163,82 +165,82 @@ permalink: /style-guide/
         </div>
       </div>
       {% endif %}
-      <div class="rounded-3xl border border-slate-200 bg-white/70 p-6 shadow-sm backdrop-blur">
-        <h3 class="text-base font-semibold text-slate-900">Dynamic CSS variables</h3>
-        <dl class="mt-4 grid gap-4 text-sm text-slate-600 sm:grid-cols-2">
+      <div class="card-surface rounded-3xl border p-6 backdrop-blur">
+        <h3 class="text-base font-semibold text-on-card">Dynamic CSS variables</h3>
+        <dl class="mt-4 grid gap-4 text-sm text-on-card-muted sm:grid-cols-2">
           <div>
-            <dt class="font-semibold text-slate-900">--sky-background-color</dt>
+            <dt class="font-semibold text-on-card">--sky-background-color</dt>
             <dd>Current sky midpoint applied to the document root and theme colour meta tag.</dd>
           </div>
           <div>
-            <dt class="font-semibold text-slate-900">--sky-background-rgb</dt>
+            <dt class="font-semibold text-on-card">--sky-background-rgb</dt>
             <dd>Pre-calculated RGB channel values for WebGL and canvas effects.</dd>
           </div>
           <div>
-            <dt class="font-semibold text-slate-900">--dynamic-text-on-background</dt>
+            <dt class="font-semibold text-on-card">--dynamic-text-on-background</dt>
             <dd>Primary type colour that adapts based on the background’s luminance.</dd>
           </div>
           <div>
-            <dt class="font-semibold text-slate-900">--dynamic-glass-background</dt>
+            <dt class="font-semibold text-on-card">--dynamic-glass-background</dt>
             <dd>Controls glassmorphism surfaces, ensuring cards stay legible whether the sky is bright or midnight dark.</dd>
           </div>
           <div>
-            <dt class="font-semibold text-slate-900">--dynamic-control-surface</dt>
+            <dt class="font-semibold text-on-card">--dynamic-control-surface</dt>
             <dd>Base background for buttons, chips, and interactive controls layered on glass panels.</dd>
           </div>
         </dl>
       </div>
-      <div class="rounded-3xl border border-slate-200 bg-white/70 p-6 shadow-sm backdrop-blur">
-        <h3 class="text-base font-semibold text-slate-900">Adaptive accent palette</h3>
-        <p class="mt-2 text-sm text-slate-600">
+      <div class="card-surface rounded-3xl border p-6 backdrop-blur">
+        <h3 class="text-base font-semibold text-on-card">Adaptive accent palette</h3>
+        <p class="mt-2 text-sm text-on-card-muted">
           Accent tokens are generated by <code class="font-mono text-xs text-slate-500">applyDynamicPalette</code> so that buttons, links, and highlights shift harmoniously with the sky background.
         </p>
         <div class="mt-4 grid gap-4 sm:grid-cols-2">
           <div class="flex items-center gap-3">
-            <span class="h-10 w-10 rounded-full border border-slate-200" style="background: var(--dynamic-accent);"></span>
+            <span class="h-10 w-10 rounded-full border border-dynamic" style="background: var(--dynamic-accent);"></span>
             <div>
-              <p class="text-sm font-semibold text-slate-900">Accent base</p>
-              <p class="text-xs text-slate-500"><code>--dynamic-accent</code></p>
+              <p class="text-sm font-semibold text-on-card">Accent base</p>
+              <p class="text-xs text-on-card-muted"><code>--dynamic-accent</code></p>
             </div>
           </div>
           <div class="flex items-center gap-3">
-            <span class="h-10 w-10 rounded-full border border-slate-200" style="background: var(--dynamic-accent-hover);"></span>
+            <span class="h-10 w-10 rounded-full border border-dynamic" style="background: var(--dynamic-accent-hover);"></span>
             <div>
-              <p class="text-sm font-semibold text-slate-900">Hover state</p>
-              <p class="text-xs text-slate-500"><code>--dynamic-accent-hover</code></p>
+              <p class="text-sm font-semibold text-on-card">Hover state</p>
+              <p class="text-xs text-on-card-muted"><code>--dynamic-accent-hover</code></p>
             </div>
           </div>
           <div class="flex items-center gap-3">
-            <span class="h-10 w-10 rounded-full border border-slate-200" style="background: var(--dynamic-accent-strong);"></span>
+            <span class="h-10 w-10 rounded-full border border-dynamic" style="background: var(--dynamic-accent-strong);"></span>
             <div>
-              <p class="text-sm font-semibold text-slate-900">Emphasis fill</p>
-              <p class="text-xs text-slate-500"><code>--dynamic-accent-strong</code></p>
+              <p class="text-sm font-semibold text-on-card">Emphasis fill</p>
+              <p class="text-xs text-on-card-muted"><code>--dynamic-accent-strong</code></p>
             </div>
           </div>
           <div class="flex items-center gap-3">
-            <span class="h-10 w-10 rounded-full border border-slate-200" style="background: var(--dynamic-accent-muted);"></span>
+            <span class="h-10 w-10 rounded-full border border-dynamic" style="background: var(--dynamic-accent-muted);"></span>
             <div>
-              <p class="text-sm font-semibold text-slate-900">Muted wash</p>
-              <p class="text-xs text-slate-500"><code>--dynamic-accent-muted</code></p>
+              <p class="text-sm font-semibold text-on-card">Muted wash</p>
+              <p class="text-xs text-on-card-muted"><code>--dynamic-accent-muted</code></p>
             </div>
           </div>
           <div class="flex items-center gap-3">
             <span
-              class="flex h-10 w-10 items-center justify-center rounded-full border border-slate-200"
+              class="flex h-10 w-10 items-center justify-center rounded-full border border-dynamic"
               style="background: var(--dynamic-accent); color: var(--dynamic-accent-contrast);"
             >
               Aa
             </span>
             <div>
-              <p class="text-sm font-semibold text-slate-900">Contrast text</p>
-              <p class="text-xs text-slate-500"><code>--dynamic-accent-contrast</code></p>
+              <p class="text-sm font-semibold text-on-card">Contrast text</p>
+              <p class="text-xs text-on-card-muted"><code>--dynamic-accent-contrast</code></p>
             </div>
           </div>
         </div>
       </div>
-      <div class="rounded-3xl border border-slate-200 bg-white/70 p-6 shadow-sm backdrop-blur">
-        <h3 class="text-base font-semibold text-slate-900">Navigation glass tokens</h3>
-        <p class="mt-2 text-sm text-slate-600">
+      <div class="card-surface rounded-3xl border p-6 backdrop-blur">
+        <h3 class="text-base font-semibold text-on-card">Navigation glass tokens</h3>
+        <p class="mt-2 text-sm text-on-card-muted">
           Overlay, divider, and shadow colours used by the floating navigation are also palette-aware, keeping the menu legible regardless of background choice.
         </p>
         <div class="mt-4 grid gap-4 sm:grid-cols-2">
@@ -248,32 +250,32 @@ permalink: /style-guide/
               style="background: var(--dynamic-nav-panel-background); border-color: var(--dynamic-nav-panel-border);"
             ></span>
             <div>
-              <p class="text-sm font-semibold text-slate-900">Nav panel</p>
-              <p class="text-xs text-slate-500"><code>--dynamic-nav-panel-background</code></p>
+              <p class="text-sm font-semibold text-on-card">Nav panel</p>
+              <p class="text-xs text-on-card-muted"><code>--dynamic-nav-panel-background</code></p>
             </div>
           </div>
           <div class="flex items-center gap-3">
-            <span class="h-10 w-10 rounded-full border border-slate-200" style="background: var(--dynamic-nav-overlay);"></span>
+            <span class="h-10 w-10 rounded-full border border-dynamic" style="background: var(--dynamic-nav-overlay);"></span>
             <div>
-              <p class="text-sm font-semibold text-slate-900">Backdrop overlay</p>
-              <p class="text-xs text-slate-500"><code>--dynamic-nav-overlay</code></p>
+              <p class="text-sm font-semibold text-on-card">Backdrop overlay</p>
+              <p class="text-xs text-on-card-muted"><code>--dynamic-nav-overlay</code></p>
             </div>
           </div>
           <div class="flex items-center gap-3">
-            <span class="h-10 w-10 rounded-full border border-slate-200" style="background: rgba(var(--dynamic-nav-divider-rgb), 1);"></span>
+            <span class="h-10 w-10 rounded-full border border-dynamic" style="background: rgba(var(--dynamic-nav-divider-rgb), 1);"></span>
             <div>
-              <p class="text-sm font-semibold text-slate-900">Divider tint</p>
-              <p class="text-xs text-slate-500"><code>--dynamic-nav-divider-rgb</code></p>
+              <p class="text-sm font-semibold text-on-card">Divider tint</p>
+              <p class="text-xs text-on-card-muted"><code>--dynamic-nav-divider-rgb</code></p>
             </div>
           </div>
           <div class="flex items-center gap-3">
             <span
-              class="h-10 w-10 rounded-full border border-slate-200 shadow-lg"
+              class="h-10 w-10 rounded-full border border-dynamic shadow-lg"
               style="background: rgba(var(--dynamic-shadow-rgb), 0.18); box-shadow: 0 12px 22px rgba(var(--dynamic-shadow-rgb), 0.25);"
             ></span>
             <div>
-              <p class="text-sm font-semibold text-slate-900">Shadow colour</p>
-              <p class="text-xs text-slate-500"><code>--dynamic-shadow-rgb</code></p>
+              <p class="text-sm font-semibold text-on-card">Shadow colour</p>
+              <p class="text-xs text-on-card-muted"><code>--dynamic-shadow-rgb</code></p>
             </div>
           </div>
         </div>
@@ -290,15 +292,15 @@ permalink: /style-guide/
         helpers so colour adapts with the sky.
       </p>
     </div>
-    <div class="space-y-6 rounded-3xl border border-slate-200 bg-white/80 p-6 shadow-sm backdrop-blur">
+    <div class="card-surface space-y-6 rounded-3xl border p-6 backdrop-blur">
       <div class="space-y-2">
-        <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">Headings</p>
+        <p class="text-on-card-muted text-xs font-semibold uppercase tracking-[0.3em]">Headings</p>
         <h1 class="text-dynamic text-4xl font-semibold sm:text-5xl">H1 – Impact headline</h1>
         <h2 class="text-dynamic text-3xl font-semibold sm:text-4xl">H2 – Section title</h2>
         <h3 class="text-dynamic text-2xl font-semibold">H3 – Card or panel title</h3>
       </div>
       <div class="space-y-3">
-        <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">Body copy</p>
+        <p class="text-on-card-muted text-xs font-semibold uppercase tracking-[0.3em]">Body copy</p>
         <p class="text-dynamic-muted text-lg leading-relaxed">
           Use <code class="font-mono text-sm text-slate-500">text-lg</code> for introductions and lead paragraphs, stepping down to
           <code class="font-mono text-sm text-slate-500">text-base</code> for supporting content.
@@ -318,14 +320,14 @@ permalink: /style-guide/
         Buttons either sit directly on the dynamic background or on glass panels. Keep padding generous and maintain rounded-full silhouettes for primary calls to action.
       </p>
     </div>
-    <div class="space-y-4 rounded-3xl border border-slate-200 bg-white/80 p-6 shadow-sm backdrop-blur">
+    <div class="card-surface space-y-4 rounded-3xl border p-6 backdrop-blur">
       <div class="flex flex-wrap items-center gap-4">
         <a
           class="inline-flex items-center justify-center rounded-full bg-brand px-6 py-3 text-base font-semibold text-white shadow-soft-xl transition hover:bg-brand-dark focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand"
           href="#"
         >Primary action</a>
         <a
-          class="inline-flex items-center justify-center rounded-full border border-slate-200 bg-white/80 px-6 py-3 text-base font-semibold text-slate-900 shadow-sm transition hover:border-brand hover:text-brand focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand"
+          class="inline-flex items-center justify-center rounded-full border border-transparent bg-[var(--dynamic-card-background)] px-6 py-3 text-base font-semibold text-[var(--dynamic-card-text)] shadow-sm transition hover:bg-[var(--dynamic-control-surface-hover)] hover:text-[var(--dynamic-card-text)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand"
           href="#"
         >Secondary</a>
         <button
@@ -336,7 +338,7 @@ permalink: /style-guide/
           Glass toggle
         </button>
       </div>
-      <p class="text-sm text-slate-600">
+      <p class="text-on-card-muted text-sm">
         Controls inherit stateful colours from the CSS custom properties updated by <code class="font-mono text-xs text-slate-500">applyDynamicPalette</code> in <code class="font-mono text-xs text-slate-500">_layouts/default.html</code>.
       </p>
     </div>
@@ -346,7 +348,7 @@ permalink: /style-guide/
     <div class="space-y-4">
       <h2 class="text-dynamic text-2xl font-semibold">Cards &amp; glass surfaces</h2>
       <p class="text-dynamic-muted text-base leading-relaxed">
-        Two primary surface treatments are available: frosted glass for hero panels and solid white cards for dense content. Mix them to create visual hierarchy.
+        Two primary surface treatments are available: pair <code class="font-mono text-sm text-slate-500">glass-dynamic</code> panels with luminous backgrounds and rely on <code class="font-mono text-sm text-slate-500">card-surface</code> for dense content blocks. Mix them to create visual hierarchy.
       </p>
     </div>
     <div class="grid gap-6 md:grid-cols-2">
@@ -370,13 +372,13 @@ permalink: /style-guide/
           </div>
         </div>
       </div>
-      <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
-        <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">Solid card</p>
-        <h3 class="text-slate-900 text-xl font-semibold">Supporting detail</h3>
-        <p class="mt-3 text-base text-slate-600">
+      <div class="card-surface rounded-3xl border p-6">
+        <p class="text-on-card-muted text-xs font-semibold uppercase tracking-[0.3em]">Solid card</p>
+        <h3 class="text-on-card text-xl font-semibold">Supporting detail</h3>
+        <p class="mt-3 text-base text-on-card-muted">
           Solid cards are ideal for structured lists, metrics, and dense content that benefits from a calm backdrop.
         </p>
-        <ul class="mt-4 space-y-2 text-sm text-slate-500">
+        <ul class="mt-4 space-y-2 text-sm text-on-card-muted">
           <li class="flex items-center gap-2">
             <span class="h-1.5 w-1.5 rounded-full bg-brand"></span>
             Uses standard border + shadow stack
@@ -397,7 +399,7 @@ permalink: /style-guide/
         Quick copy/paste helpers when building new sections. Adjust copy only; structural classes keep spacing, alignment, and colour rules intact.
       </p>
     </div>
-    <div class="space-y-4 rounded-3xl border border-slate-200 bg-white/80 p-6 shadow-sm backdrop-blur">
+    <div class="card-surface space-y-4 rounded-3xl border p-6 backdrop-blur">
       <pre class="overflow-x-auto rounded-2xl bg-slate-900 p-4 text-sm text-slate-100"><code>&lt;section class=&quot;py-16&quot;&gt;
   &lt;div class=&quot;mx-auto max-w-6xl px-6&quot;&gt;
     &lt;div class=&quot;grid gap-10 lg:grid-cols-[minmax(0,0.45fr)_minmax(0,1fr)]&quot;&gt;
@@ -410,9 +412,9 @@ permalink: /style-guide/
     &lt;/div&gt;
   &lt;/div&gt;
 &lt;/section&gt;</code></pre>
-      <pre class="overflow-x-auto rounded-2xl bg-slate-900 p-4 text-sm text-slate-100"><code>&lt;article class=&quot;group rounded-3xl border border-slate-200 bg-white p-6 shadow-sm transition hover:-translate-y-1 hover:shadow-xl&quot;&gt;
-  &lt;h3 class=&quot;text-xl font-semibold text-slate-900 group-hover:text-brand&quot;&gt;Card title&lt;/h3&gt;
-  &lt;p class=&quot;mt-3 text-base text-slate-600&quot;&gt;Body copy for a supporting card.&lt;/p&gt;
+      <pre class="overflow-x-auto rounded-2xl bg-slate-900 p-4 text-sm text-slate-100"><code>&lt;article class=&quot;card-surface group rounded-3xl border p-6 transition hover:-translate-y-1&quot;&gt;
+  &lt;h3 class=&quot;text-xl font-semibold text-on-card group-hover:text-brand&quot;&gt;Card title&lt;/h3&gt;
+  &lt;p class=&quot;mt-3 text-base text-on-card-muted&quot;&gt;Body copy for a supporting card.&lt;/p&gt;
   &lt;span class=&quot;mt-4 inline-flex items-center text-sm font-semibold text-brand&quot;&gt;Call to action →&lt;/span&gt;
 &lt;/article&gt;</code></pre>
     </div>

--- a/style-guide.md
+++ b/style-guide.md
@@ -133,10 +133,10 @@ permalink: /style-guide/
       </div>
       {% if background.time_ranges %}
       <div class="rounded-3xl border border-slate-200 bg-white/70 p-6 shadow-sm backdrop-blur">
-        <h3 class="text-base font-semibold text-slate-900">Time-aware sky gradients</h3>
+        <h3 class="text-base font-semibold text-slate-900">Time-aware sky colours</h3>
         <p class="mt-2 text-sm text-slate-600">
           These ranges animate automatically in the browser, ensuring cards and navigation pick light or dark treatments that
-          match the current sky.
+          match the current sky tone.
         </p>
         <div class="mt-5 grid gap-4 lg:grid-cols-2">
           {% for range in background.time_ranges %}
@@ -148,8 +148,7 @@ permalink: /style-guide/
           {% else %}
           {% assign end_display = '%02d' | format: end_hour %}
           {% endif %}
-          {% assign top_color = range.gradient.top | default: range.top | default: range.color | default: background.color %}
-          {% assign bottom_color = range.gradient.bottom | default: range.bottom | default: range.color | default: top_color %}
+          {% assign solid_color = range.color | default: range.top | default: background.color %}
           <div class="flex flex-col gap-3 rounded-2xl border border-slate-200 bg-white/80 p-4 shadow-sm backdrop-blur">
             <div class="flex flex-wrap items-center justify-between gap-3">
               <p class="text-sm font-semibold uppercase tracking-[0.25em] text-slate-500">{{ range.label }}</p>
@@ -157,7 +156,7 @@ permalink: /style-guide/
             </div>
             <div
               class="h-12 w-full rounded-xl border border-slate-200"
-              style="background: linear-gradient(135deg, {{ top_color }}, {{ bottom_color }});"
+              style="background: {{ solid_color }};"
             ></div>
           </div>
           {% endfor %}
@@ -174,14 +173,6 @@ permalink: /style-guide/
           <div>
             <dt class="font-semibold text-slate-900">--sky-background-rgb</dt>
             <dd>Pre-calculated RGB channel values for WebGL and canvas effects.</dd>
-          </div>
-          <div>
-            <dt class="font-semibold text-slate-900">--sky-gradient-top</dt>
-            <dd>Active gradient start colour mirrored from the current sky preset.</dd>
-          </div>
-          <div>
-            <dt class="font-semibold text-slate-900">--sky-gradient-bottom</dt>
-            <dd>Active gradient end colour that complements navigation and card treatments.</dd>
           </div>
           <div>
             <dt class="font-semibold text-slate-900">--dynamic-text-on-background</dt>


### PR DESCRIPTION
## Summary
- swap the gradient-driven background for a solid tone that still updates with the time-based presets
- refresh the time-range configuration to provide dedicated colours for each period
- update the style guide documentation to reflect the solid background implementation and remove gradient variables

## Testing
- bundle exec jekyll serve -H 0.0.0.0 -P 4000

------
https://chatgpt.com/codex/tasks/task_e_68de5cea1b248324b4a425b72306c9d1