### PR TITLE
Prevent background transition animation on initial load

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -308,6 +308,25 @@
       const fallbackColor = hexToRgb(fallbackHexNormalized) || { r: 3, g: 7, b: 18 };
       const BACKGROUND_UPDATE_INTERVAL = 5 * 60 * 1000;
 
+      let backgroundTransitionsReady = false;
+      const enableBackgroundTransitions = () => {
+        if (backgroundTransitionsReady) {
+          return;
+        }
+
+        const rootElement = document.documentElement;
+        if (!rootElement) {
+          return;
+        }
+
+        backgroundTransitionsReady = true;
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            rootElement.classList.add('sky-background-transition-ready');
+          });
+        });
+      };
+
       const rgbToHsl = (color) => {
         if (!color) {
           return { h: 0, s: 0, l: 0 };
@@ -515,6 +534,7 @@
         }
 
         applyDynamicPalette(topColor, bottomColor);
+        enableBackgroundTransitions();
       };
 
       applyBackground();

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -63,6 +63,10 @@ html {
   background-color: var(--sky-background-color, #030712);
   background-image: none;
   background-repeat: no-repeat;
+  transition: none;
+}
+
+html.sky-background-transition-ready {
   transition: background-color 0.6s ease, background-image 0.6s ease;
 }
 


### PR DESCRIPTION
## Summary
- disable background transitions on the initial paint
- enable transitions after the background script runs to keep dynamic updates smooth

## Testing
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68de8588bca08324afd6d0b2a8fdf079