### PR TITLE
Fix desktop nav positioning

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -508,10 +508,9 @@ body {
 
 @media (min-width: 768px) {
   .site-nav {
-    position: relative;
-    top: auto;
-    right: auto;
-    align-self: center;
+    position: fixed;
+    top: var(--header-nav-top);
+    right: var(--header-edge);
   }
 
   .site-nav__list {


### PR DESCRIPTION
## Summary
- keep the desktop navigation container fixed to the viewport so the menu remains visible while the page scrolls

## Testing
- bundle exec jekyll serve --livereload --host 0.0.0.0 --port 4000

------
https://chatgpt.com/codex/tasks/task_e_68de85b2781083249f6535da970e565f