### PR TITLE
Implement minute-by-minute sky palette interpolation

### DIFF
--- a/_data/background.yml
+++ b/_data/background.yml
@@ -1,24 +1,19 @@
 color: "#030712"
 label: "Midnight canvas"
 description: "Primary background colour applied across the site."
-time_ranges:
+time_points:
   - label: "Night watch"
-    start_hour: 0
-    end_hour: 5
+    time: "00:00"
     color: "#070c1c"
   - label: "First light"
-    start_hour: 5
-    end_hour: 8
+    time: "05:00"
     color: "#163381"
   - label: "Daybreak blue"
-    start_hour: 8
-    end_hour: 17
+    time: "08:00"
     color: "#a8cefd"
   - label: "Golden hour"
-    start_hour: 17
-    end_hour: 20
+    time: "17:00"
     color: "#884c35"
   - label: "Evening hush"
-    start_hour: 20
-    end_hour: 24
+    time: "20:00"
     color: "#070c19"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -228,28 +228,100 @@
         return { top, bottom, label };
       };
 
-      const mapTimeRanges = () => {
-        if (!backgroundData || !Array.isArray(backgroundData.time_ranges)) {
-          return [];
+      const parseTimeToMinutes = (value) => {
+        const TOTAL_MINUTES = 24 * 60;
+
+        if (typeof value === 'number' && Number.isFinite(value)) {
+          const clampedHours = Math.max(0, Math.min(24, value));
+          return Math.round(clampedHours * 60);
         }
 
-        return backgroundData.time_ranges
-          .map((range) => {
+        if (typeof value === 'string') {
+          const trimmed = value.trim();
+          if (!trimmed) {
+            return null;
+          }
+
+          const match = trimmed.match(/^(\d{1,2})(?::(\d{1,2}))?$/);
+          if (!match) {
+            return null;
+          }
+
+          const hours = Number.parseInt(match[1], 10);
+          const minutes = match[2] ? Number.parseInt(match[2], 10) : 0;
+
+          if (Number.isNaN(hours) || Number.isNaN(minutes)) {
+            return null;
+          }
+
+          if (hours === 24 && minutes === 0) {
+            return 0;
+          }
+
+          if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59) {
+            return null;
+          }
+
+          return hours * 60 + minutes;
+        }
+
+        return null;
+      };
+
+      const mapTimeAnchors = () => {
+        const anchors = new Map();
+        const TOTAL_MINUTES = 24 * 60;
+
+        const registerAnchor = (minutes, entry) => {
+          if (!Number.isFinite(minutes)) {
+            return;
+          }
+
+          const normalizedMinutes = ((minutes % TOTAL_MINUTES) + TOTAL_MINUTES) % TOTAL_MINUTES;
+          const config = buildBackgroundConfig(entry, backgroundData?.label);
+          if (!config) {
+            return;
+          }
+
+          const topHex = normalizeHex(config.top);
+          const bottomHex = normalizeHex(config.bottom || config.top);
+
+          if (!topHex && !bottomHex) {
+            return;
+          }
+
+          anchors.set(normalizedMinutes, {
+            minutes: normalizedMinutes,
+            top: topHex || bottomHex,
+            bottom: bottomHex || topHex,
+            label: config.label
+          });
+        };
+
+        if (backgroundData && Array.isArray(backgroundData.time_points)) {
+          backgroundData.time_points.forEach((point) => {
+            if (!point || typeof point !== 'object') {
+              return;
+            }
+
+            const minutes =
+              parseTimeToMinutes(point.time) ??
+              parseTimeToMinutes(typeof point.hour === 'number' ? point.hour : null);
+
+            registerAnchor(minutes, point);
+          });
+        } else if (backgroundData && Array.isArray(backgroundData.time_ranges)) {
+          backgroundData.time_ranges.forEach((range) => {
             if (!range || typeof range !== 'object') {
-              return null;
+              return;
             }
 
-            const config = buildBackgroundConfig(range, backgroundData.label);
-            if (!config) {
-              return null;
-            }
+            const startMinutes = parseTimeToMinutes(range.start_hour);
+            registerAnchor(startMinutes, range);
+          });
+        }
 
-            const startHour = typeof range.start_hour === 'number' ? range.start_hour : null;
-            const endHour = typeof range.end_hour === 'number' ? range.end_hour : null;
-
-            return { ...config, startHour, endHour };
-          })
-          .filter(Boolean);
+        return Array.from(anchors.values()).sort((a, b) => a.minutes - b.minutes);
       };
 
       const getDefaultBackground = () => {
@@ -262,43 +334,81 @@
         return { top: FALLBACK_BACKGROUND_HEX, bottom: FALLBACK_BACKGROUND_HEX, label: backgroundData?.label || '' };
       };
 
-      const resolveActiveTimeRange = () => {
-        const ranges = mapTimeRanges();
-        if (!ranges.length) {
+      const resolveInterpolatedBackground = () => {
+        const anchors = mapTimeAnchors();
+        if (!anchors.length) {
           return null;
         }
 
+        if (anchors.length === 1) {
+          const single = anchors[0];
+          return {
+            top: single.top,
+            bottom: single.bottom,
+            label: single.label
+          };
+        }
+
+        const TOTAL_MINUTES = 24 * 60;
         const now = new Date();
-        const currentHour = now.getHours() + now.getMinutes() / 60 + now.getSeconds() / 3600;
+        const currentMinutes = now.getHours() * 60 + now.getMinutes() + now.getSeconds() / 60;
 
-        for (const range of ranges) {
-          if (typeof range.startHour !== 'number' || typeof range.endHour !== 'number') {
-            continue;
-          }
+        let previous = anchors[anchors.length - 1];
+        let next = anchors[0];
 
-          const start = Math.max(0, Math.min(24, range.startHour));
-          const rawEnd = Math.max(0, Math.min(24, range.endHour));
-          const end = rawEnd === 0 && range.endHour !== 0 ? 24 : rawEnd;
-
-          if (start <= end) {
-            if (currentHour >= start && currentHour < end) {
-              return range;
-            }
+        for (const anchor of anchors) {
+          if (currentMinutes >= anchor.minutes) {
+            previous = anchor;
           } else {
-            if (currentHour >= start || currentHour < end) {
-              return range;
-            }
+            next = anchor;
+            break;
           }
         }
 
-        return ranges[0];
+        if (previous.minutes === next.minutes) {
+          return {
+            top: previous.top,
+            bottom: previous.bottom,
+            label: previous.label
+          };
+        }
+
+        let startMinutes = previous.minutes;
+        let endMinutes = next.minutes;
+
+        if (endMinutes <= startMinutes) {
+          endMinutes += TOTAL_MINUTES;
+        }
+
+        let elapsed = currentMinutes - startMinutes;
+        if (elapsed < 0) {
+          elapsed += TOTAL_MINUTES;
+        }
+
+        const duration = endMinutes - startMinutes;
+        const mixFactor = duration === 0 ? 0 : clamp01(elapsed / duration);
+
+        const startTop = hexToRgb(previous.top) || fallbackColor;
+        const endTop = hexToRgb(next.top) || startTop;
+        const startBottom = hexToRgb(previous.bottom) || startTop;
+        const endBottom = hexToRgb(next.bottom) || endTop;
+
+        const topColor = mixRgb(startTop, endTop, mixFactor) || startTop;
+        const bottomColor = mixRgb(startBottom, endBottom, mixFactor) || startBottom;
+
+        const label = mixFactor < 0.5 ? previous.label : next.label || previous.label;
+
+        return {
+          top: rgbToHex(topColor),
+          bottom: rgbToHex(bottomColor),
+          label
+        };
       };
 
       const getActiveBackground = () => {
-        const activeRange = resolveActiveTimeRange();
-        if (activeRange) {
-          const { startHour, endHour, ...config } = activeRange;
-          return config;
+        const interpolated = resolveInterpolatedBackground();
+        if (interpolated) {
+          return interpolated;
         }
 
         return getDefaultBackground();
@@ -306,7 +416,7 @@
 
       const fallbackHexNormalized = normalizeHex(FALLBACK_BACKGROUND_HEX) || '#030712';
       const fallbackColor = hexToRgb(fallbackHexNormalized) || { r: 3, g: 7, b: 18 };
-      const BACKGROUND_UPDATE_INTERVAL = 5 * 60 * 1000;
+      const BACKGROUND_UPDATE_INTERVAL = 60 * 1000;
 
       let backgroundTransitionsReady = false;
       const enableBackgroundTransitions = () => {

--- a/style-guide.md
+++ b/style-guide.md
@@ -80,8 +80,8 @@ permalink: /style-guide/
       <p class="text-dynamic-muted text-base leading-relaxed">
         The site’s sky backdrop is orchestrated from
         <code class="rounded bg-slate-900/10 px-1.5 py-0.5 text-sm text-slate-900">_data/background.yml</code>.
-        Each visitor receives a palette that shifts with their local time of day, while the fallback colour keeps feeds and
-        print exports consistent.
+        Anchor swatches are defined at precise times, then the client interpolates the background and glassmorphism palette
+        every minute so cards, typography, and UI chrome stay readable as the sky evolves.
       </p>
       <div class="grid gap-3">
         <div class="flex items-center gap-3">
@@ -133,32 +133,31 @@ permalink: /style-guide/
           </div>
         </dl>
       </div>
-      {% if background.time_ranges %}
+      {% assign time_points = background.time_points %}
+      {% if time_points %}
       <div class="card-surface rounded-3xl border p-6 backdrop-blur">
-        <h3 class="text-base font-semibold text-on-card">Time-aware sky colours</h3>
+        <h3 class="text-base font-semibold text-on-card">Time-aware sky anchors</h3>
         <p class="mt-2 text-sm text-on-card-muted">
-          These ranges animate automatically in the browser, ensuring cards and navigation pick light or dark treatments that
-          match the current sky tone.
+          Each anchor specifies the palette at a 24-hour timestamp. The runtime script blends between anchors once per minute,
+          keeping card surfaces and on-background type legible as daylight shifts.
         </p>
         <div class="mt-5 grid gap-4 lg:grid-cols-2">
-          {% for range in background.time_ranges %}
-          {% assign start_hour = range.start_hour | default: 0 %}
-          {% assign end_hour = range.end_hour | default: 0 %}
-          {% assign start_display = '%02d' | format: start_hour %}
-          {% if end_hour == 24 %}
-          {% assign end_display = '00' %}
+          {% for point in time_points %}
+          {% assign top_color = point.color | default: point.top | default: point.gradient.top | default: background.color %}
+          {% assign bottom_color = point.bottom | default: point.gradient.bottom | default: top_color %}
+          {% if bottom_color and bottom_color != top_color %}
+          {% capture swatch_style %}background: linear-gradient(135deg, {{ top_color }}, {{ bottom_color }});{% endcapture %}
           {% else %}
-          {% assign end_display = '%02d' | format: end_hour %}
+          {% capture swatch_style %}background: {{ top_color }};{% endcapture %}
           {% endif %}
-          {% assign solid_color = range.color | default: range.top | default: background.color %}
           <div class="card-surface rounded-2xl border p-4 backdrop-blur">
             <div class="flex flex-wrap items-center justify-between gap-3">
-              <p class="text-sm font-semibold uppercase tracking-[0.25em] text-on-card-muted">{{ range.label }}</p>
-              <p class="font-mono text-xs text-on-card-muted">{{ start_display }}:00 – {{ end_display }}:00</p>
+              <p class="text-sm font-semibold uppercase tracking-[0.25em] text-on-card-muted">{{ point.label }}</p>
+              <p class="font-mono text-xs text-on-card-muted">{{ point.time }}</p>
             </div>
             <div
               class="h-12 w-full rounded-xl border border-dynamic"
-              style="background: {{ solid_color }};"
+              style="{{ swatch_style }}"
             ></div>
           </div>
           {% endfor %}


### PR DESCRIPTION
## Summary
- replace hourly background ranges with explicit time anchors that define the sky palette
- interpolate between sky anchors in the client script so the background, cards, and typography adjust every minute
- document the new anchor-driven timeline in the style guide with swatches for each timestamp

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de9c6c615c8324a6641cb2e0b65ae8