### PR TITLE
Fix clamp unit calculations in stylesheet

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -256,14 +256,14 @@ strong {
 }
 
 .section-title {
-  font-size: clamp(2.5rem, 2.1rem + 2vw, 4.5rem);
+  font-size: clamp(2.5rem, calc(2.1rem + 2vw), 4.5rem);
   font-weight: 900;
   line-height: 1.05;
   letter-spacing: -0.01em;
 }
 
 .section-heading {
-  font-size: clamp(1.75rem, 1.5rem + 1vw, 2.5rem);
+  font-size: clamp(1.75rem, calc(1.5rem + 1vw), 2.5rem);
   font-weight: 800;
   text-transform: uppercase;
   letter-spacing: 0.2em;
@@ -279,7 +279,7 @@ strong {
 .two-tone-box {
   position: relative;
   border-radius: 1.75rem;
-  padding: clamp(1.75rem, 1.4rem + 1.5vw, 2.5rem);
+  padding: clamp(1.75rem, calc(1.4rem + 1.5vw), 2.5rem);
   display: flex;
   flex-direction: column;
   gap: 2rem;
@@ -346,7 +346,7 @@ strong {
 }
 
 .two-tone-details__value {
-  font-size: clamp(1.1rem, 1rem + 0.6vw, 1.35rem);
+  font-size: clamp(1.1rem, calc(1rem + 0.6vw), 1.35rem);
   font-weight: 700;
 }
 
@@ -395,7 +395,7 @@ strong {
 .two-tone-panel {
   position: relative;
   border-radius: 1.5rem;
-  padding: clamp(1.75rem, 1.4rem + 1vw, 2.35rem);
+  padding: clamp(1.75rem, calc(1.4rem + 1vw), 2.35rem);
   display: flex;
   flex-direction: column;
   gap: 1rem;


### PR DESCRIPTION
## Summary
- wrap clamp expressions that mixed rem and vw units with calc to prevent Sass from performing invalid unit arithmetic
- ensure responsive typography and spacing utilities compile successfully under the GitHub Pages Sass pipeline

## Testing
- bundle exec jekyll build *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68dfb8e11bf883248104fd6333ccdb81