### PR TITLE
Restore neutral body text with accent inversion

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -60,6 +60,18 @@
       };
     };
 
+    const invertRgb = (color) => {
+      if (!color) {
+        return WHITE;
+      }
+
+      return {
+        r: 255 - color.r,
+        g: 255 - color.g,
+        b: 255 - color.b
+      };
+    };
+
     const WHITE = { r: 255, g: 255, b: 255 };
     const BLACK = { r: 0, g: 0, b: 0 };
     const BASE_DARK = { r: 15, g: 23, b: 42 };
@@ -249,11 +261,22 @@
       }
 
       const backgroundHsl = rgbToHsl(background);
-      const complementaryHue = (backgroundHsl.h + 0.5) % 1;
+      const inverted = invertRgb(background);
+      const invertedHsl = rgbToHsl(inverted);
+      const complementaryHue = Number.isFinite(backgroundHsl.h)
+        ? (backgroundHsl.h + 0.5) % 1
+        : invertedHsl.h || 0;
+
+      const targetLightnessBase = Number.isFinite(backgroundHsl.l)
+        ? backgroundHsl.l >= 0.5
+          ? backgroundHsl.l - 0.5
+          : backgroundHsl.l + 0.5
+        : 0.5;
+
       const complementHsl = {
         h: complementaryHue,
-        s: clamp01(Math.max(0.5, backgroundHsl.s * 1.1)),
-        l: 0.52
+        s: clamp01(Math.max(0.55, invertedHsl.s, backgroundHsl.s)),
+        l: clamp01(targetLightnessBase)
       };
 
       let tone = hslToRgb(complementHsl);
@@ -261,7 +284,7 @@
 
       if (getContrastRatio(tone, background) < 6.5) {
         const fallback = getMostContrastingColor(background);
-        tone = mixRgb(tone, fallback, 0.35) || fallback;
+        tone = mixRgb(tone, fallback, 0.5) || fallback;
       }
 
       return tone;
@@ -276,6 +299,17 @@
 
     const getReadableTextOn = (background) => {
       return getMostContrastingColor(background);
+    };
+
+    const getBinaryContrastingColor = (background) => {
+      if (!background) {
+        return WHITE;
+      }
+
+      const contrastWithWhite = getContrastRatio(WHITE, background);
+      const contrastWithBlack = getContrastRatio(BLACK, background);
+
+      return contrastWithWhite >= contrastWithBlack ? WHITE : BLACK;
     };
 
     const rgbaToString = (color, alpha = 1) => {
@@ -511,10 +545,10 @@
         return;
       }
 
-      const foreground = getComplementaryTone(baseColor);
-      const muted = mixRgb(foreground, baseColor, 0.45);
-      const surfaceBackground = mixRgb(baseColor, foreground, 0.18);
-      const surfaceBorder = mixRgb(baseColor, foreground, 0.35);
+      const accent = getComplementaryTone(baseColor);
+      const foreground = getBinaryContrastingColor(baseColor);
+      const surfaceBackground = mixRgb(baseColor, accent, 0.18);
+      const surfaceBorder = mixRgb(baseColor, accent, 0.35);
       const baseHex = rgbToHex(baseColor);
       const rootElement = document.documentElement;
 
@@ -524,12 +558,12 @@
 
       const palette = {
         '--dynamic-text-on-background': rgbToString(foreground),
-        '--dynamic-text-muted': rgbToString(muted),
+        '--dynamic-text-muted': rgbaToString(foreground, 0.72),
         '--two-tone-background': baseHex,
         '--two-tone-background-rgb': rgbValuesToString(baseColor),
-        '--two-tone-foreground': rgbToString(foreground),
-        '--two-tone-foreground-rgb': rgbValuesToString(foreground),
-        '--two-tone-foreground-muted': rgbToString(muted),
+        '--two-tone-foreground': rgbToString(accent),
+        '--two-tone-foreground-rgb': rgbValuesToString(accent),
+        '--two-tone-foreground-muted': rgbaToString(accent, 0.72),
         '--surface-background': rgbToString(surfaceBackground),
         '--surface-background-rgb': rgbValuesToString(surfaceBackground),
         '--surface-border': rgbaToString(surfaceBorder, 0.22)

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -135,6 +135,18 @@
         };
       };
 
+      const invertRgb = (color) => {
+        if (!color) {
+          return WHITE;
+        }
+
+        return {
+          r: 255 - color.r,
+          g: 255 - color.g,
+          b: 255 - color.b
+        };
+      };
+
       const WHITE = { r: 255, g: 255, b: 255 };
       const BLACK = { r: 0, g: 0, b: 0 };
       const BASE_DARK = { r: 15, g: 23, b: 42 };
@@ -262,19 +274,30 @@
         }
 
         const backgroundHsl = rgbToHsl(background);
-        const complementaryHue = (backgroundHsl.h + 0.5) % 1;
+        const inverted = invertRgb(background);
+        const invertedHsl = rgbToHsl(inverted);
+        const complementaryHue = Number.isFinite(backgroundHsl.h)
+          ? (backgroundHsl.h + 0.5) % 1
+          : invertedHsl.h || 0;
+
+        const targetLightnessBase = Number.isFinite(backgroundHsl.l)
+          ? backgroundHsl.l >= 0.5
+            ? backgroundHsl.l - 0.5
+            : backgroundHsl.l + 0.5
+          : 0.5;
+
         const complementHsl = {
           h: complementaryHue,
-          s: clamp01(Math.max(0.5, backgroundHsl.s * 1.1)),
-          l: 0.52
+          s: clamp01(Math.max(0.55, invertedHsl.s, backgroundHsl.s)),
+          l: clamp01(targetLightnessBase)
         };
 
         let tone = hslToRgb(complementHsl);
         tone = ensureComplementContrast(tone, background, complementaryHue) || tone;
 
-        if (getContrastRatio(tone, background) < 4.5) {
+        if (getContrastRatio(tone, background) < 6.5) {
           const fallback = getMostContrastingColor(background);
-          tone = mixRgb(tone, fallback, 0.35) || fallback;
+          tone = mixRgb(tone, fallback, 0.5) || fallback;
         }
 
         return tone;
@@ -282,6 +305,17 @@
 
       const getReadableTextOn = (background) => {
         return getMostContrastingColor(background);
+      };
+
+      const getBinaryContrastingColor = (background) => {
+        if (!background) {
+          return WHITE;
+        }
+
+        const contrastWithWhite = getContrastRatio(WHITE, background);
+        const contrastWithBlack = getContrastRatio(BLACK, background);
+
+        return contrastWithWhite >= contrastWithBlack ? WHITE : BLACK;
       };
 
       const rgbaToString = (color, alpha = 1) => {
@@ -613,10 +647,10 @@
           return;
         }
 
-        const foreground = getComplementaryTone(baseColor);
-        const surfaceBackground = mixRgb(baseColor, foreground, 0.18);
-        const surfaceBorder = mixRgb(baseColor, foreground, 0.35);
-        const mutedText = mixRgb(foreground, baseColor, 0.45);
+        const accent = getComplementaryTone(baseColor);
+        const foreground = getBinaryContrastingColor(baseColor);
+        const surfaceBackground = mixRgb(baseColor, accent, 0.18);
+        const surfaceBorder = mixRgb(baseColor, accent, 0.35);
         const baseHex = rgbToHex(baseColor);
         const rootElement = document.documentElement;
 
@@ -626,12 +660,12 @@
 
         const palette = {
           '--dynamic-text-on-background': rgbToString(foreground),
-          '--dynamic-text-muted': rgbToString(mutedText),
+          '--dynamic-text-muted': rgbaToString(foreground, 0.72),
           '--two-tone-background': baseHex,
           '--two-tone-background-rgb': rgbValuesToString(baseColor),
-          '--two-tone-foreground': rgbToString(foreground),
-          '--two-tone-foreground-rgb': rgbValuesToString(foreground),
-          '--two-tone-foreground-muted': rgbToString(mutedText),
+          '--two-tone-foreground': rgbToString(accent),
+          '--two-tone-foreground-rgb': rgbValuesToString(accent),
+          '--two-tone-foreground-muted': rgbaToString(accent, 0.72),
           '--surface-background': rgbToString(surfaceBackground),
           '--surface-background-rgb': rgbValuesToString(surfaceBackground),
           '--surface-border': rgbaToString(surfaceBorder, 0.22)


### PR DESCRIPTION
## Summary
- add a helper that picks black or white body copy based on contrast with the active background
- keep the inverted complementary tone for accent variables while reverting primary text tokens to the neutral color

## Testing
- npm run build:css

------
https://chatgpt.com/codex/tasks/task_e_68e0045908d48324a1c53eabeec308e4