### PR TITLE
Remove hero gradient and align document background

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="bg-charcoal-950">
   <head>
     {% include head.html %}
   </head>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -10,10 +10,6 @@ layout: default
   id="profile"
   class="relative overflow-hidden border-b border-aluminum-500/20 bg-graphite-800/80"
 >
-  <div class="absolute inset-0 -z-10">
-    <div class="absolute left-1/2 top-0 h-80 w-80 -translate-x-1/2 rounded-full bg-ember-500/25 blur-3xl"></div>
-    <div class="absolute bottom-0 left-0 h-72 w-72 -translate-x-1/3 translate-y-1/3 rounded-full bg-ember-400/15 blur-3xl"></div>
-  </div>
   <div class="mx-auto flex min-h-[75vh] max-w-5xl flex-col justify-center gap-10 px-6 py-24">
     <div class="space-y-6">
       <span class="inline-flex items-center rounded-full border border-ember-400/30 bg-ember-500/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.4em] text-ember-200 texture-noise"


### PR DESCRIPTION
## Summary
- remove the circular gradient overlays from the hero profile section so it inherits the section background
- set the root html element background to charcoal to match the body and avoid browser chrome contrast issues

## Testing
- bundle exec jekyll serve --livereload --host 0.0.0.0 --port 4000

------
https://chatgpt.com/codex/tasks/task_e_68e28eb8b3f0832483fed050e6d32dcc