### PR TITLE
Limit sticky section nav to upcoming sections

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -60,8 +60,8 @@ layout: default
   aria-label="On this page"
   data-sticky-nav
 >
-  <div class="mx-auto max-w-5xl px-6">
-    <div class="flex gap-3 overflow-x-auto py-4 text-sm" data-nav-scroll>
+  <div class="mx-auto w-full max-w-5xl">
+    <div class="flex gap-3 overflow-x-auto px-6 py-4 text-sm" data-nav-scroll>
       <a class="whitespace-nowrap rounded-full border border-transparent px-4 py-2 font-medium text-aluminum-300 transition hover:text-aluminum-100 hover:border-aluminum-500/40 aria-[current=page]:border-ember-400/50 aria-[current=page]:bg-ember-500/10 aria-[current=page]:text-ember-200 aria-[current=page]:texture-noise"
         href="#profile"
         data-nav-link

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -57,8 +57,8 @@ layout: default
 
   {% if page.nav %}
   <nav class="sticky top-0 z-40 border-b border-aluminum-500/25 bg-charcoal-900/95 backdrop-blur" aria-label="Page sections" data-sticky-nav>
-    <div class="mx-auto max-w-4xl px-6">
-      <div class="flex gap-3 overflow-x-auto py-4 text-sm" data-nav-scroll>
+    <div class="mx-auto w-full max-w-4xl">
+      <div class="flex gap-3 overflow-x-auto px-6 py-4 text-sm" data-nav-scroll>
         {% for item in page.nav %}
         <a class="whitespace-nowrap rounded-full border border-transparent px-4 py-2 font-medium text-aluminum-300 transition hover:text-aluminum-100 hover:border-aluminum-500/40 aria-[current=page]:border-ember-400/50 aria-[current=page]:bg-ember-500/10 aria-[current=page]:text-ember-200 aria-[current=page]:texture-noise"
           href="#{{ item.id }}"

--- a/assets/js/page-nav.js
+++ b/assets/js/page-nav.js
@@ -32,35 +32,37 @@
         return;
       }
 
-      const sections = links
-        .map((link) => {
+      const linkItems = links
+        .map((link, index) => {
           const href = link.getAttribute('href') || '';
           if (!href.startsWith('#')) {
             return null;
           }
           const id = href.slice(1);
           const section = document.getElementById(id);
-          if (section) {
-            section.dataset.navIndex = section.dataset.navIndex || String(links.indexOf(link));
+          if (!section) {
+            return null;
           }
-          return section;
+          section.dataset.navIndex = section.dataset.navIndex || String(index);
+          return { link, section };
         })
         .filter(Boolean);
 
-      if (!sections.length) {
+      if (!linkItems.length) {
         return;
       }
+
+      const itemsById = new Map(linkItems.map((item) => [item.section.id, item]));
 
       let currentId = null;
 
       function setActive(id, { fromHash = false } = {}) {
-        if (!id || id === currentId) {
+        if (id === currentId) {
           return;
         }
-        currentId = id;
-        links.forEach((link) => {
-          const targetId = (link.getAttribute('href') || '').replace('#', '');
-          if (targetId === id) {
+        currentId = id || null;
+        linkItems.forEach(({ link, section }) => {
+          if (id && section.id === id && !link.hidden) {
             link.setAttribute('aria-current', 'page');
             if (!fromHash) {
               scrollLinkIntoView(scrollContainer, link);
@@ -71,28 +73,62 @@
         });
       }
 
-      function findCurrentSection() {
-        const navHeight = nav.offsetHeight + 24;
-        let activeSection = sections[0];
-        for (const section of sections) {
+      function updateSectionOffsets() {
+        const navHeight = nav.offsetHeight;
+        linkItems.forEach(({ section }) => {
+          section.style.scrollMarginTop = `${navHeight}px`;
+        });
+      }
+
+      function updateVisibleLinks() {
+        const navBottom = nav.getBoundingClientRect().bottom;
+        const visibleItems = [];
+        linkItems.forEach((item) => {
+          const { link, section } = item;
           const rect = section.getBoundingClientRect();
-          if (rect.top - navHeight <= 0) {
-            activeSection = section;
+          const isBelowNav = rect.bottom > navBottom;
+          if (isBelowNav) {
+            if (link.hidden) {
+              link.hidden = false;
+            }
+            link.removeAttribute('aria-hidden');
+            link.tabIndex = 0;
+            visibleItems.push(item);
           } else {
-            break;
+            if (!link.hidden) {
+              link.hidden = true;
+            }
+            link.setAttribute('aria-hidden', 'true');
+            link.tabIndex = -1;
           }
-        }
-        return activeSection;
+        });
+        return visibleItems;
       }
 
-      function handleScroll() {
-        const section = findCurrentSection();
-        if (section) {
-          setActive(section.id);
+      function handleScroll({ fromHash = false } = {}) {
+        const visibleItems = updateVisibleLinks();
+        if (visibleItems.length) {
+          setActive(visibleItems[0].section.id, { fromHash });
+        } else {
+          setActive(null, { fromHash });
         }
       }
 
-      handleScroll();
+      function scrollToSection(section, { behavior } = {}) {
+        if (!section) {
+          return;
+        }
+        const navHeight = nav.offsetHeight;
+        const targetTop = window.pageYOffset + section.getBoundingClientRect().top - navHeight;
+        window.scrollTo({
+          top: targetTop,
+          behavior: behavior || (reduceMotionQuery.matches ? 'auto' : 'smooth'),
+        });
+      }
+
+      updateSectionOffsets();
+      handleScroll({ fromHash: true });
+
       window.addEventListener(
         'scroll',
         () => {
@@ -100,32 +136,29 @@
         },
         { passive: true }
       );
-      window.addEventListener(
-        'resize',
-        () => {
-          window.requestAnimationFrame(handleScroll);
-        }
-      );
+
+      window.addEventListener('resize', () => {
+        updateSectionOffsets();
+        window.requestAnimationFrame(() => handleScroll({ fromHash: true }));
+      });
 
       if (window.location.hash) {
         const hashId = window.location.hash.slice(1);
-        if (sections.some((section) => section.id === hashId)) {
+        const item = itemsById.get(hashId);
+        if (item) {
+          scrollToSection(item.section, { behavior: 'auto' });
           setActive(hashId, { fromHash: true });
-          const targetSection = document.getElementById(hashId);
-          if (targetSection) {
-            targetSection.scrollIntoView();
-          }
+          window.requestAnimationFrame(() => handleScroll({ fromHash: true }));
         }
       }
 
-      links.forEach((link) => {
-        link.addEventListener('click', () => {
-          const href = link.getAttribute('href');
-          if (!href || !href.startsWith('#')) {
-            return;
-          }
-          const id = href.slice(1);
-          setActive(id);
+      linkItems.forEach(({ link, section }) => {
+        link.addEventListener('click', (event) => {
+          event.preventDefault();
+          scrollToSection(section, {});
+          window.history.replaceState(null, '', `#${section.id}`);
+          setActive(section.id);
+          window.requestAnimationFrame(handleScroll);
         });
       });
     });


### PR DESCRIPTION
## Summary
- make the sticky section nav scroll area span edge-to-edge on smaller screens while keeping internal padding
- update the nav logic to hide links for sections that sit above the viewport and to offset anchor scrolling by the nav height
- apply the same nav container adjustments to project layouts for consistency

## Testing
- bundle exec jekyll serve --livereload --host 0.0.0.0 --port 4000


------
https://chatgpt.com/codex/tasks/task_e_68e62efa96c08324b01544ddf462c43a