### PR TITLE
Make hero experience years dynamic

### DIFF
--- a/_data/cv.yml
+++ b/_data/cv.yml
@@ -1,5 +1,6 @@
 profile: >-
-  A results-driven leader with 10 years of British Army management experience and expertise in mobile app development within the consumer software sector. Proven ability to leverage technology for enhanced efficiency and team performance. Skilled in project and product management, and operational efficiency. Recognised for strong interpersonal skills, adaptability, and a commitment to excellence. Currently pursuing an MBA in Technology Management.
+  A results-driven leader with [[experience_years]] years of British Army management experience and expertise in mobile app development within the consumer software sector. Proven ability to leverage technology for enhanced efficiency and team performance. Skilled in project and product management, and operational efficiency. Recognised for strong interpersonal skills, adaptability, and a commitment to excellence. Currently pursuing an MBA in Technology Management.
+career_start: 2012-01-01
 competencies:
   - title: Project Leadership & Strategic Influence
     description: Proven ability to establish clear purpose, influence cross-functional teams, and champion business requirements to achieve strategic objectives and deliver complex software projects effectively.

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -5,6 +5,22 @@ layout: default
 {% assign ordered_projects = site.projects | sort: 'order' %}
 {% assign case_studies = ordered_projects | where: 'type', 'Case study' %}
 {% assign app_builds = ordered_projects | where: 'type', 'App build' %}
+{% assign career_start_date = cv.career_start | default: '2014-07-01' %}
+{% assign start_year = career_start_date | date: '%Y' | plus: 0 %}
+{% assign start_month = career_start_date | date: '%m' | plus: 0 %}
+{% assign current_year = 'now' | date: '%Y' | plus: 0 %}
+{% assign current_month = 'now' | date: '%m' | plus: 0 %}
+{% assign experience_years = current_year | minus: start_year %}
+{% assign experience_months = current_month | minus: start_month %}
+{% if experience_months < 0 %}
+  {% assign experience_years = experience_years | minus: 1 %}
+  {% assign experience_months = experience_months | plus: 12 %}
+{% endif %}
+{% assign experience_years_text = experience_years %}
+{% if experience_months >= 6 %}
+  {% assign experience_years_text = experience_years_text | append: '+' %}
+{% endif %}
+{% assign profile_text = cv.profile | replace: '[[experience_years]]', experience_years_text %}
 
 <section
   id="profile"
@@ -17,7 +33,7 @@ layout: default
       >
       <h1 class="text-4xl font-semibold text-aluminum-100 sm:text-5xl">Hello, I’m Liam Day</h1>
       <p class="max-w-3xl text-lg leading-relaxed text-aluminum-300">
-        {{ cv.profile }}
+        {{ profile_text }}
       </p>
       <div class="flex flex-wrap gap-4">
         <a class="inline-flex items-center justify-center rounded-full bg-ember-400 px-6 py-3 text-sm font-semibold text-charcoal-950 shadow-glow transition texture-noise hover:bg-ember-300"
@@ -33,7 +49,7 @@ layout: default
     <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
       <div class="surface-panel p-6">
         <p class="text-sm uppercase tracking-[0.3em] text-aluminum-400">Experience</p>
-        <p class="mt-3 text-2xl font-semibold text-aluminum-100">10+ years</p>
+        <p class="mt-3 text-2xl font-semibold text-aluminum-100">{{ experience_years_text }} years</p>
         <p class="mt-2 text-sm text-aluminum-400">Leadership roles across defence and consumer software.</p>
       </div>
       <div class="surface-panel p-6">


### PR DESCRIPTION
## Summary
- compute the total British Army experience duration from the configured career start date
- render the hero profile summary and experience stat with the dynamically calculated years value

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68e65aca72f08324b68c2a0a6c158968