### PR TITLE
Fix experience years calculation on home page

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -5,9 +5,48 @@ layout: default
 {% assign ordered_projects = site.projects | sort: 'order' %}
 {% assign case_studies = ordered_projects | where: 'type', 'Case study' %}
 {% assign app_builds = ordered_projects | where: 'type', 'App build' %}
-{% assign career_start_date = cv.career_start | default: '2014-07-01' %}
-{% assign start_year = career_start_date | date: '%Y' | plus: 0 %}
-{% assign start_month = career_start_date | date: '%m' | plus: 0 %}
+{% assign earliest_start_date = '' %}
+
+{% for experience in cv.employment %}
+  {% assign normalized_period = experience.period | replace: '–', '-' %}
+  {% assign start_part = normalized_period | split: '-' | first | strip %}
+  {% if start_part != '' %}
+    {% assign normalized_start = start_part | date: '%Y-%m-01' %}
+    {% assign candidate_timestamp = normalized_start | date: '%s' | plus: 0 %}
+    {% if earliest_start_date == '' %}
+      {% assign earliest_start_date = normalized_start %}
+    {% else %}
+      {% assign earliest_timestamp = earliest_start_date | date: '%s' | plus: 0 %}
+      {% if candidate_timestamp < earliest_timestamp %}
+        {% assign earliest_start_date = normalized_start %}
+      {% endif %}
+    {% endif %}
+  {% endif %}
+{% endfor %}
+
+{% for experience in site.experiences %}
+  {% assign normalized_period = experience.period | replace: '–', '-' %}
+  {% assign start_part = normalized_period | split: '-' | first | strip %}
+  {% if start_part != '' %}
+    {% assign normalized_start = start_part | date: '%Y-%m-01' %}
+    {% assign candidate_timestamp = normalized_start | date: '%s' | plus: 0 %}
+    {% if earliest_start_date == '' %}
+      {% assign earliest_start_date = normalized_start %}
+    {% else %}
+      {% assign earliest_timestamp = earliest_start_date | date: '%s' | plus: 0 %}
+      {% if candidate_timestamp < earliest_timestamp %}
+        {% assign earliest_start_date = normalized_start %}
+      {% endif %}
+    {% endif %}
+  {% endif %}
+{% endfor %}
+
+{% if earliest_start_date == '' %}
+  {% assign earliest_start_date = cv.career_start | default: '2014-07-01' %}
+{% endif %}
+
+{% assign start_year = earliest_start_date | date: '%Y' | plus: 0 %}
+{% assign start_month = earliest_start_date | date: '%m' | plus: 0 %}
 {% assign current_year = 'now' | date: '%Y' | plus: 0 %}
 {% assign current_month = 'now' | date: '%m' | plus: 0 %}
 {% assign experience_years = current_year | minus: start_year %}


### PR DESCRIPTION
## Summary
- derive the experience start date from the earliest employment or experience entry instead of the static career_start field
- fall back to the previous configuration value if no dated entries exist

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68e65ffd8050832483202b5d7c3cbcdd