### PR TITLE
Switch experience bullets to styled list markers

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -132,12 +132,9 @@ layout: default
           <p class="text-xs font-semibold uppercase tracking-[0.35em] text-aluminum-400">{{ role.period }}</p>
         </div>
         {% if role.highlights %}
-        <ul class="mt-6 space-y-3 text-sm leading-relaxed text-aluminum-300">
+        <ul class="mt-6 list-disc space-y-3 pl-6 text-sm leading-relaxed text-aluminum-300 marker:text-ember-300">
           {% for highlight in role.highlights %}
-          <li class="flex gap-3">
-            <span class="mt-1 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-ember-300/80 texture-noise"></span>
-            <span>{{ highlight }}</span>
-          </li>
+          <li>{{ highlight }}</li>
           {% endfor %}
         </ul>
         {% endif %}
@@ -190,12 +187,9 @@ layout: default
       </div>
       <div class="space-y-6 surface-panel p-8">
         <h3 class="text-sm font-semibold uppercase tracking-[0.3em] text-aluminum-300">Certifications</h3>
-        <ul class="space-y-3 text-sm leading-relaxed text-aluminum-300">
+        <ul class="list-disc space-y-3 pl-6 text-sm leading-relaxed text-aluminum-300 marker:text-ember-300">
           {% for certification in cv.certifications %}
-          <li class="flex gap-3">
-            <span class="mt-1 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-ember-300/80 texture-noise"></span>
-            <span>{{ certification }}</span>
-          </li>
+          <li>{{ certification }}</li>
           {% endfor %}
         </ul>
       </div>


### PR DESCRIPTION
## Summary
- replace the custom flex-based bullets in the experience highlights with default list markers and orange marker styling
- update the certifications list to use the same default marker approach for consistent alignment

## Testing
- bundle exec jekyll serve --host 0.0.0.0 --port 4000

------
https://chatgpt.com/codex/tasks/task_e_68e6605cf214832495d3cd82f7a59b92