### PR TITLE
Remove hero section from sticky nav

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -118,11 +118,6 @@ layout: default
   <div class="mx-auto w-full max-w-5xl">
     <div class="flex gap-3 overflow-x-auto px-6 py-4 text-sm" data-nav-scroll>
       <a class="whitespace-nowrap rounded-full border border-transparent px-4 py-2 font-medium text-aluminum-300 transition hover:text-aluminum-100 hover:border-aluminum-500/40 aria-[current=page]:border-ember-400/50 aria-[current=page]:bg-ember-500/10 aria-[current=page]:text-ember-200 aria-[current=page]:texture-noise"
-        href="#profile"
-        data-nav-link
-        >Profile</a
-      >
-      <a class="whitespace-nowrap rounded-full border border-transparent px-4 py-2 font-medium text-aluminum-300 transition hover:text-aluminum-100 hover:border-aluminum-500/40 aria-[current=page]:border-ember-400/50 aria-[current=page]:bg-ember-500/10 aria-[current=page]:text-ember-200 aria-[current=page]:texture-noise"
         href="#experience"
         data-nav-link
         >Experience</a

--- a/assets/js/page-nav.js
+++ b/assets/js/page-nav.js
@@ -80,35 +80,21 @@
         });
       }
 
-      function updateVisibleLinks() {
+      function getVisibleItems() {
         const navBottom = nav.getBoundingClientRect().bottom;
-        const visibleItems = [];
-        linkItems.forEach((item) => {
-          const { link, section } = item;
+        return linkItems.filter((item) => {
+          const { section } = item;
           const rect = section.getBoundingClientRect();
-          const isBelowNav = rect.bottom > navBottom;
-          if (isBelowNav) {
-            if (link.hidden) {
-              link.hidden = false;
-            }
-            link.removeAttribute('aria-hidden');
-            link.tabIndex = 0;
-            visibleItems.push(item);
-          } else {
-            if (!link.hidden) {
-              link.hidden = true;
-            }
-            link.setAttribute('aria-hidden', 'true');
-            link.tabIndex = -1;
-          }
+          return rect.bottom > navBottom;
         });
-        return visibleItems;
       }
 
       function handleScroll({ fromHash = false } = {}) {
-        const visibleItems = updateVisibleLinks();
+        const visibleItems = getVisibleItems();
         if (visibleItems.length) {
           setActive(visibleItems[0].section.id, { fromHash });
+        } else if (linkItems.length) {
+          setActive(linkItems[linkItems.length - 1].section.id, { fromHash });
         } else {
           setActive(null, { fromHash });
         }


### PR DESCRIPTION
## Summary
- remove the hero section from the sticky navigation menu so the bar only lists sections below its initial position
- simplify the sticky navigation script so links remain visible while still tracking the active section

## Testing
- bundle exec jekyll serve --livereload --host 0.0.0.0 --port 4000

------
https://chatgpt.com/codex/tasks/task_e_68e667801e78832488b927f6720f90a7