### PR TITLE
Adjust section min height to exclude sticky navigation

### DIFF
--- a/assets/js/page-nav.js
+++ b/assets/js/page-nav.js
@@ -75,8 +75,10 @@
 
       function updateSectionOffsets() {
         const navHeight = nav.offsetHeight;
+        const minHeight = Math.max(window.innerHeight - navHeight, 0);
         linkItems.forEach(({ section }) => {
           section.style.scrollMarginTop = `${navHeight}px`;
+          section.style.minHeight = `${minHeight}px`;
         });
       }
 


### PR DESCRIPTION
## Summary
- ensure sections linked from the sticky navigation have their minimum height reduced by the nav height so the nav headings are excluded from the total height

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e67dc2eff48324845dac6303122aa2