### PR TITLE
Update footer built with links to official sources

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,8 +20,8 @@
           <span aria-hidden="true">·</span>
           <p>
             Built with
-            <a href="https://jekyllrb.com/community/" class="transition hover:text-ember-300">Jekyll</a>,
-            <a href="https://tailwindcss.com/community" class="transition hover:text-ember-300">Tailwind CSS</a>,
+            <a href="https://jekyllrb.com/" class="transition hover:text-ember-300">Jekyll</a>,
+            <a href="https://tailwindcss.com/" class="transition hover:text-ember-300">Tailwind CSS</a>,
             and
             <a href="https://greensock.com/gsap/" class="transition hover:text-ember-300">GSAP</a>.
           </p>


### PR DESCRIPTION
## Summary
- update the Jekyll and Tailwind CSS footer links to point at their official homepages

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e7b2305bfc8324801cd73ab4c6ac1d