### PR TITLE
Update hero stats headings styling

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -48,22 +48,22 @@ layout: default
     </div>
     <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
       <div class="surface-panel p-6" data-animate="hero-stat">
-        <p class="text-sm uppercase tracking-[0.3em] text-aluminum-400">Experience</p>
+        <p class="text-sm uppercase tracking-[0.3em] text-ember-200">Experience</p>
         <p class="mt-3 text-2xl font-semibold text-aluminum-100">{{ experience_years_text }} years</p>
         <p class="mt-2 text-sm text-aluminum-400">Leadership roles across defence and consumer software.</p>
       </div>
       <div class="surface-panel p-6" data-animate="hero-stat">
-        <p class="text-sm uppercase tracking-[0.3em] text-aluminum-400">Current focus</p>
+        <p class="text-sm uppercase tracking-[0.3em] text-ember-200">Current focus</p>
         <p class="mt-3 text-2xl font-semibold text-aluminum-100">Product operations</p>
         <p class="mt-2 text-sm text-aluminum-400">Strengthening release quality and customer feedback loops.</p>
       </div>
       <div class="surface-panel p-6" data-animate="hero-stat">
-        <p class="text-sm uppercase tracking-[0.3em] text-aluminum-400">Studies</p>
+        <p class="text-sm uppercase tracking-[0.3em] text-ember-200">Education</p>
         <p class="mt-3 text-2xl font-semibold text-aluminum-100">MBA candidate</p>
         <p class="mt-2 text-sm text-aluminum-400">Technology Management · Open University (2026 expected).</p>
       </div>
       <div class="surface-panel p-6" data-animate="hero-stat">
-        <p class="text-sm uppercase tracking-[0.3em] text-aluminum-400">Based in</p>
+        <p class="text-sm uppercase tracking-[0.3em] text-ember-200">Based in</p>
         <p class="mt-3 text-2xl font-semibold text-aluminum-100">Winchester, UK</p>
         <p class="mt-2 text-sm text-aluminum-400">UK citizen with full right to work.</p>
       </div>


### PR DESCRIPTION
## Summary
- update the hero stats labels to use the ember accent colour
- rename the studies label to education to match the requested wording

## Testing
- bundle exec jekyll serve --host 0.0.0.0 --port 4000

------
https://chatgpt.com/codex/tasks/task_e_68e7cb09aa74832496ebc537e34aa770