### PR TITLE
Fix scroll snap by applying snap type to html root

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="en" class="bg-charcoal-900">
+<html lang="en" class="bg-charcoal-900 snap-y snap-proximity motion-reduce:snap-none">
   <head>
     {% include head.html %}
   </head>
-  <body class="flex min-h-screen flex-col bg-charcoal-900 text-aluminum-100 antialiased snap-y snap-proximity motion-reduce:snap-none">
+  <body class="flex min-h-screen flex-col bg-charcoal-900 text-aluminum-100 antialiased">
     <a
       class="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:rounded-md focus:bg-aluminum-100 focus:px-4 focus:py-2 focus:text-charcoal-950"
       href="#main"


### PR DESCRIPTION
## Summary
- move the scroll snap type classes from the body to the html element so the root scroller honors the snap points
- keep the body styling focused on layout and typography while leaving snapping to the viewport

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68e8d75c3c488324ae568aeabf87b4f3