### PR TITLE
Increase footer minimum height for snap scrolling

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,7 +13,7 @@
       {{ content }}
     </main>
 
-    <footer class="border-t border-aluminum-500/25 bg-charcoal-900">
+    <footer class="border-t border-aluminum-500/25 bg-charcoal-900 min-h-[50vh]">
       <div class="mx-auto flex w-full max-w-5xl flex-col gap-4 px-6 py-10 text-sm text-aluminum-400">
         <div class="flex flex-wrap items-center gap-3">
           <p>© {{ 'now' | date: '%Y' }} {{ site.title }}</p>


### PR DESCRIPTION
## Summary
- give the site footer a minimum height of 50vh so it can be scrolled into view when snap scrolling is enabled

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e8de50b2cc8324a0fe547c8f401d4c