### PR TITLE
Add border and nowrap styling to date capsules

### DIFF
--- a/_includes/date-period.html
+++ b/_includes/date-period.html
@@ -1,3 +1,3 @@
-<span class="inline-flex items-center justify-center rounded-full bg-aluminum-800/60 px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-aluminum-200 {{ include.class | default: '' }}">
+<span class="inline-flex items-center justify-center whitespace-nowrap rounded-full border border-aluminum-500/60 bg-aluminum-800/60 px-4 py-1 text-center text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-aluminum-200 {{ include.class | default: '' }}">
   {{ include.period }}
 </span>


### PR DESCRIPTION
## Summary
- update the shared date-period include so experience and education dates render in bordered capsules
- increase capsule padding, center the text, and prevent wrapping for consistent alignment with surrounding content

## Testing
- bundle exec jekyll serve --livereload --host 0.0.0.0 --port 4000

------
https://chatgpt.com/codex/tasks/task_e_68e8e86f3ee48324894d814705e0b0b5