### PR TITLE
Add projects landing page and Swift app project templates

### DIFF
--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -1,20 +1,79 @@
 ---
 layout: default
 ---
+{% assign default_store_sections = false %}
+{% if page.type and page.type == 'App build' %}
+  {% assign default_store_sections = true %}
+{% endif %}
+{% if page.show_store_sections != nil %}
+  {% assign show_store_sections = page.show_store_sections %}
+{% else %}
+  {% assign show_store_sections = default_store_sections %}
+{% endif %}
+
 <article class="bg-charcoal-900 text-aluminum-100">
-  <section class="border-b border-aluminum-500/25 bg-charcoal-900">
-    <div class="mx-auto max-w-4xl px-6 py-20">
-      <a class="text-sm text-aluminum-300 underline-offset-4 transition hover:text-ember-300 hover:underline" href="{{ '/' | relative_url }}"
-        >← Back to portfolio</a
-      >
-      {% if page.type %}
-      <p class="mt-8 text-xs font-semibold uppercase tracking-[0.35em] text-aluminum-400">{{ page.type }}</p>
+  <section
+    id="project-hero"
+    class="relative flex min-h-screen flex-col justify-center overflow-hidden border-b border-aluminum-500/20 bg-charcoal-900"
+  >
+    <div class="mx-auto flex w-full max-w-4xl flex-col gap-12 px-6 py-24">
+      <div class="space-y-6" data-animate="hero-copy">
+        <a
+          class="inline-flex w-fit items-center gap-2 rounded-full border border-aluminum-500/30 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-aluminum-300 transition hover:border-ember-400/50 hover:text-ember-200"
+          href="{{ '/projects/' | relative_url }}"
+          >← Back to projects</a
+        >
+        {% if page.type %}
+        <span class="inline-flex w-fit items-center rounded-full border border-ember-400/30 bg-ember-500/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.4em] text-ember-200 texture-noise"
+          >{{ page.type }}</span
+        >
+        {% endif %}
+        <h1 class="text-4xl font-semibold text-aluminum-100 sm:text-5xl" data-animate="hero-heading">{{ page.title }}</h1>
+        {% if page.summary %}
+        <p class="max-w-3xl text-lg leading-relaxed text-aluminum-300" data-animate="hero-text">{{ page.summary }}</p>
+        {% endif %}
+        <div class="flex flex-wrap gap-4" data-animate="hero-actions">
+          {% if page.app_store_url %}
+          <a
+            class="inline-flex items-center justify-center rounded-full bg-ember-400 px-6 py-3 text-sm font-semibold text-charcoal-950 shadow-glow transition texture-noise hover:bg-ember-300"
+            href="{{ page.app_store_url }}"
+            >View on the App Store</a
+          >
+          {% endif %}
+          {% if page.repository_url %}
+          <a
+            class="inline-flex items-center justify-center rounded-full border border-aluminum-500/25 px-6 py-3 text-sm font-semibold text-aluminum-100 transition hover:border-ember-400/40 hover:bg-ember-500/10"
+            href="{{ page.repository_url }}"
+            >View source</a
+          >
+          {% endif %}
+          {% if page.case_study_url %}
+          <a
+            class="inline-flex items-center justify-center rounded-full border border-aluminum-500/25 px-6 py-3 text-sm font-semibold text-aluminum-100 transition hover:border-ember-400/40 hover:bg-ember-500/10"
+            href="{{ page.case_study_url }}"
+            >Read the case study</a
+          >
+          {% endif %}
+        </div>
+      </div>
+      {% if page.stats %}
+      <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {% for stat in page.stats %}
+        <div class="surface-panel p-6" data-animate="hero-stat">
+          {% if stat.label %}
+          <p class="text-sm uppercase tracking-[0.3em] text-ember-200">{{ stat.label }}</p>
+          {% endif %}
+          {% if stat.value %}
+          <p class="mt-3 text-2xl font-semibold text-aluminum-100">{{ stat.value }}</p>
+          {% endif %}
+          {% if stat.description %}
+          <p class="mt-2 text-sm text-aluminum-400">{{ stat.description }}</p>
+          {% endif %}
+        </div>
+        {% endfor %}
+      </div>
       {% endif %}
-      <h1 class="mt-6 text-4xl font-semibold text-aluminum-100">{{ page.title }}</h1>
-      {% if page.summary %}
-      <p class="mt-4 text-lg leading-relaxed text-aluminum-300">{{ page.summary }}</p>
-      {% endif %}
-      <dl class="mt-12 grid gap-6 rounded-2xl border border-aluminum-500/25 bg-graphite-700/60 p-6 text-sm text-aluminum-300 sm:grid-cols-2 lg:grid-cols-3">
+      <dl class="grid gap-6 rounded-2xl border border-aluminum-500/25 bg-graphite-700/60 p-6 text-sm text-aluminum-300 sm:grid-cols-2 lg:grid-cols-3">
         {% if page.role %}
         <div>
           <dt class="text-aluminum-400">Role</dt>
@@ -51,31 +110,101 @@ layout: default
           <dd class="mt-1 text-aluminum-100">{{ page.outcome }}</dd>
         </div>
         {% endif %}
+        {% if page.platforms %}
+        <div>
+          <dt class="text-aluminum-400">Platforms</dt>
+          <dd class="mt-1 text-aluminum-100">{{ page.platforms }}</dd>
+        </div>
+        {% endif %}
+        {% if page.status %}
+        <div>
+          <dt class="text-aluminum-400">Status</dt>
+          <dd class="mt-1 text-aluminum-100">{{ page.status }}</dd>
+        </div>
+        {% endif %}
+        {% if page.stack %}
+        <div>
+          <dt class="text-aluminum-400">Tech stack</dt>
+          <dd class="mt-1 text-aluminum-100">{{ page.stack }}</dd>
+        </div>
+        {% endif %}
       </dl>
     </div>
   </section>
 
-  {% if page.nav %}
   <nav class="sticky top-0 z-40 border-b border-aluminum-500/25 bg-charcoal-900/95 backdrop-blur" aria-label="Page sections" data-sticky-nav>
     <div class="mx-auto w-full max-w-4xl">
-      <div class="flex gap-3 overflow-x-auto px-6 py-4 text-sm" data-nav-scroll>
-        {% for item in page.nav %}
-        <a class="whitespace-nowrap rounded-full border border-transparent px-4 py-2 font-medium text-aluminum-300 transition hover:text-aluminum-100 hover:border-aluminum-500/40 aria-[current=page]:border-ember-400/50 aria-[current=page]:bg-ember-500/10 aria-[current=page]:text-ember-200 aria-[current=page]:texture-noise"
-          href="#{{ item.id }}"
-          data-nav-link
-          >{{ item.label }}</a
+      <div class="relative flex gap-3 overflow-x-auto px-6 py-4 text-sm" data-nav-scroll>
+        <a
+          class="whitespace-nowrap rounded-full border border-aluminum-500/40 px-4 py-2 text-sm font-medium text-aluminum-300 transition hover:border-ember-400/50 hover:bg-ember-500/10 hover:text-aluminum-100"
+          href="{{ '/projects/' | relative_url }}"
+          >← Back</a
         >
-        {% endfor %}
+        {% if page.nav %}
+          {% for item in page.nav %}
+          <a
+            class="whitespace-nowrap rounded-full border border-transparent px-4 py-2 font-medium text-aluminum-300 transition hover:text-aluminum-100 hover:border-aluminum-500/40 aria-[current=page]:border-ember-400/50 aria-[current=page]:bg-ember-500/10 aria-[current=page]:text-ember-200 aria-[current=page]:texture-noise"
+            href="#{{ item.id }}"
+            data-nav-link
+            >{{ item.label }}</a
+          >
+          {% endfor %}
+        {% endif %}
+        {% if show_store_sections %}
+        <a
+          class="whitespace-nowrap rounded-full border border-transparent px-4 py-2 font-medium text-aluminum-300 transition hover:text-aluminum-100 hover:border-aluminum-500/40 aria-[current=page]:border-ember-400/50 aria-[current=page]:bg-ember-500/10 aria-[current=page]:text-ember-200 aria-[current=page]:texture-noise"
+          href="#terms"
+          data-nav-link
+          >Terms &amp; Conditions</a
+        >
+        <a
+          class="whitespace-nowrap rounded-full border border-transparent px-4 py-2 font-medium text-aluminum-300 transition hover:text-aluminum-100 hover:border-aluminum-500/40 aria-[current=page]:border-ember-400/50 aria-[current=page]:bg-ember-500/10 aria-[current=page]:text-ember-200 aria-[current=page]:texture-noise"
+          href="#privacy"
+          data-nav-link
+          >Privacy Policy</a
+        >
+        {% endif %}
       </div>
     </div>
   </nav>
-  {% endif %}
 
   <div class="mx-auto max-w-4xl px-6 py-16">
     <div class="detail-content prose prose-invert">
       {{ content }}
     </div>
   </div>
+  {% if show_store_sections %}
+  <div class="mx-auto max-w-4xl px-6 pb-12">
+    <section id="terms" class="scroll-mt-32 surface-panel p-6">
+      <h2 class="text-lg font-semibold text-aluminum-100">Terms &amp; Conditions</h2>
+      {% if page.terms_url %}
+      <p class="mt-3 text-sm leading-relaxed text-aluminum-300">
+        Review the latest terms and conditions for {{ page.title }} on the
+        <a class="underline-offset-4 hover:text-ember-300 hover:underline" href="{{ page.terms_url }}">App Store listing</a>.
+      </p>
+      {% else %}
+      <p class="mt-3 text-sm leading-relaxed text-aluminum-300">
+        Terms and conditions will be published alongside the App Store release. Reach out if you need early access.
+      </p>
+      {% endif %}
+    </section>
+  </div>
+  <div class="mx-auto max-w-4xl px-6 pb-20">
+    <section id="privacy" class="scroll-mt-32 surface-panel p-6">
+      <h2 class="text-lg font-semibold text-aluminum-100">Privacy Policy</h2>
+      {% if page.privacy_url %}
+      <p class="mt-3 text-sm leading-relaxed text-aluminum-300">
+        Access the privacy policy for {{ page.title }} via the
+        <a class="underline-offset-4 hover:text-ember-300 hover:underline" href="{{ page.privacy_url }}">App Store listing</a>.
+      </p>
+      {% else %}
+      <p class="mt-3 text-sm leading-relaxed text-aluminum-300">
+        The privacy policy will be shared with testers and listed publicly once the app is live on the App Store.
+      </p>
+      {% endif %}
+    </section>
+  </div>
+  {% endif %}
   {% if page.links %}
   <div class="mx-auto max-w-4xl px-6 pb-20">
     <div class="surface-panel p-6">

--- a/_layouts/projects.html
+++ b/_layouts/projects.html
@@ -1,0 +1,140 @@
+---
+layout: default
+---
+{% assign ordered_projects = site.projects | sort: 'order' %}
+{% assign case_studies = ordered_projects | where: 'type', 'Case study' %}
+{% assign app_builds = ordered_projects | where: 'type', 'App build' %}
+
+<section
+  id="projects-hero"
+  class="relative flex min-h-screen flex-col justify-center overflow-hidden border-b border-aluminum-500/20 bg-charcoal-900"
+>
+  <div class="mx-auto flex w-full max-w-5xl flex-col gap-10 px-6 py-24">
+    <div class="space-y-6" data-animate="hero-copy">
+      <span class="inline-flex items-center rounded-full border border-ember-400/30 bg-ember-500/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.4em] text-ember-200 texture-noise"
+        data-animate="hero-badge"
+        >Projects</span
+      >
+      <h1 class="text-4xl font-semibold text-aluminum-100 sm:text-5xl" data-animate="hero-heading">Product work &amp; experiments</h1>
+      <p class="max-w-3xl text-lg leading-relaxed text-aluminum-300" data-animate="hero-text">
+        A curated collection of shipping products, operational case studies, and Swift-based builds in progress. Each entry follows the same playbook—clear framing, measurable outcomes, and transparent release notes so partners know how I operate.
+      </p>
+    </div>
+    <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <div class="surface-panel p-6" data-animate="hero-stat">
+        <p class="text-sm uppercase tracking-[0.3em] text-ember-200">Focus</p>
+        <p class="mt-3 text-2xl font-semibold text-aluminum-100">iOS &amp; Swift</p>
+        <p class="mt-2 text-sm text-aluminum-400">Native experiences that flex from iPhone to watchOS and visionOS.</p>
+      </div>
+      <div class="surface-panel p-6" data-animate="hero-stat">
+        <p class="text-sm uppercase tracking-[0.3em] text-ember-200">Approach</p>
+        <p class="mt-3 text-2xl font-semibold text-aluminum-100">Operational rigor</p>
+        <p class="mt-2 text-sm text-aluminum-400">Discovery, QA, and analytics loops embedded from day one.</p>
+      </div>
+      <div class="surface-panel p-6" data-animate="hero-stat">
+        <p class="text-sm uppercase tracking-[0.3em] text-ember-200">In flight</p>
+        <p class="mt-3 text-2xl font-semibold text-aluminum-100">{{ app_builds | size }} builds</p>
+        <p class="mt-2 text-sm text-aluminum-400">Personal shipping lanes to test release cadences and new APIs.</p>
+      </div>
+      <div class="surface-panel p-6" data-animate="hero-stat">
+        <p class="text-sm uppercase tracking-[0.3em] text-ember-200">Case studies</p>
+        <p class="mt-3 text-2xl font-semibold text-aluminum-100">{{ case_studies | size }}</p>
+        <p class="mt-2 text-sm text-aluminum-400">Evidence of scaled delivery across defence and consumer products.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<nav class="sticky top-0 z-40 border-b border-aluminum-500/20 bg-charcoal-900/95 backdrop-blur" aria-label="Projects navigation" data-sticky-nav>
+  <div class="mx-auto w-full max-w-5xl">
+    <div class="relative flex gap-3 overflow-x-auto px-6 py-4 text-sm" data-nav-scroll>
+      <a class="whitespace-nowrap rounded-full border border-transparent px-4 py-2 font-medium text-aluminum-300 transition hover:text-aluminum-100 hover:border-aluminum-500/40 aria-[current=page]:border-ember-400/50 aria-[current=page]:bg-ember-500/10 aria-[current=page]:text-ember-200 aria-[current=page]:texture-noise" href="#case-studies" data-nav-link>Case studies</a>
+      <a class="whitespace-nowrap rounded-full border border-transparent px-4 py-2 font-medium text-aluminum-300 transition hover:text-aluminum-100 hover:border-aluminum-500/40 aria-[current=page]:border-ember-400/50 aria-[current=page]:bg-ember-500/10 aria-[current=page]:text-ember-200 aria-[current=page]:texture-noise" href="#app-builds" data-nav-link>App builds</a>
+    </div>
+  </div>
+</nav>
+
+<section id="case-studies" class="scroll-mt-32 border-b border-aluminum-500/20 bg-charcoal-900">
+  <div class="mx-auto w-full max-w-5xl px-6 py-16">
+    <div class="max-w-3xl space-y-4" data-animate="section-heading">
+      <h2 class="text-3xl font-semibold text-aluminum-100">Case studies</h2>
+      <p class="text-lg text-aluminum-300">Operational programmes where I scaled delivery practices, modernised training, and improved release quality across large teams.</p>
+    </div>
+    <div class="mt-12 grid gap-6 lg:grid-cols-2">
+      {% for project in case_studies %}
+      <article class="surface-panel flex h-full flex-col p-6 transition hover:border-ember-400/40" data-animate="project-card">
+        <div class="flex flex-col gap-3">
+          <p class="text-xs font-semibold uppercase tracking-[0.3em] text-aluminum-400">{{ project.type }}</p>
+          <h3 class="text-2xl font-semibold text-aluminum-100">
+            <a class="underline-offset-4 hover:text-ember-300 hover:underline" href="{{ project.url | relative_url }}">{{ project.title }}</a>
+          </h3>
+          <p class="text-sm leading-relaxed text-aluminum-300">{{ project.summary }}</p>
+        </div>
+        <dl class="mt-6 grid gap-4 text-xs uppercase tracking-[0.3em] text-aluminum-500 sm:grid-cols-2">
+          {% if project.client %}
+          <div>
+            <dt class="text-aluminum-500">Client</dt>
+            <dd class="mt-1 text-aluminum-300">{{ project.client }}</dd>
+          </div>
+          {% endif %}
+          {% if project.year %}
+          <div>
+            <dt class="text-aluminum-500">Period</dt>
+            <dd class="mt-1 text-aluminum-300">{{ project.year }}</dd>
+          </div>
+          {% endif %}
+        </dl>
+        <a class="mt-8 inline-flex w-fit items-center gap-2 text-sm font-semibold text-ember-300 transition hover:text-ember-200" href="{{ project.url | relative_url }}">
+          Read the story
+          <span aria-hidden="true">→</span>
+        </a>
+      </article>
+      {% endfor %}
+    </div>
+  </div>
+</section>
+
+<section id="app-builds" class="scroll-mt-32 bg-charcoal-900">
+  <div class="mx-auto w-full max-w-5xl px-6 py-16">
+    <div class="max-w-3xl space-y-4" data-animate="section-heading">
+      <h2 class="text-3xl font-semibold text-aluminum-100">App builds</h2>
+      <p class="text-lg text-aluminum-300">Hands-on SwiftUI builds exploring product ideas, automation, and measurement across Apple platforms.</p>
+    </div>
+    <div class="mt-12 grid gap-6 lg:grid-cols-2">
+      {% for project in app_builds %}
+      <article class="surface-panel flex h-full flex-col p-6 transition hover:border-ember-400/40" data-animate="project-card">
+        <div class="flex flex-col gap-3">
+          <p class="text-xs font-semibold uppercase tracking-[0.3em] text-aluminum-400">{{ project.type }}</p>
+          <h3 class="text-2xl font-semibold text-aluminum-100">
+            <a class="underline-offset-4 hover:text-ember-300 hover:underline" href="{{ project.url | relative_url }}">{{ project.title }}</a>
+          </h3>
+          <p class="text-sm leading-relaxed text-aluminum-300">{{ project.summary }}</p>
+        </div>
+        <dl class="mt-6 grid gap-4 text-xs uppercase tracking-[0.3em] text-aluminum-500 sm:grid-cols-2">
+          {% if project.platforms %}
+          <div>
+            <dt class="text-aluminum-500">Platforms</dt>
+            <dd class="mt-1 text-aluminum-300">{{ project.platforms }}</dd>
+          </div>
+          {% endif %}
+          {% if project.status %}
+          <div>
+            <dt class="text-aluminum-500">Status</dt>
+            <dd class="mt-1 text-aluminum-300">{{ project.status }}</dd>
+          </div>
+          {% elsif project.year %}
+          <div>
+            <dt class="text-aluminum-500">Year</dt>
+            <dd class="mt-1 text-aluminum-300">{{ project.year }}</dd>
+          </div>
+          {% endif %}
+        </dl>
+        <a class="mt-8 inline-flex w-fit items-center gap-2 text-sm font-semibold text-ember-300 transition hover:text-ember-200" href="{{ project.url | relative_url }}">
+          Explore the build
+          <span aria-hidden="true">→</span>
+        </a>
+      </article>
+      {% endfor %}
+    </div>
+  </div>
+</section>

--- a/projects/after-action-journal.md
+++ b/projects/after-action-journal.md
@@ -4,6 +4,19 @@ summary: Drafting a reflective operations journal that transforms field notes in
 role: Product & iOS Developer
 year: 2024
 order: 5
+platforms: iOS, iPadOS, macOS (Catalyst)
+status: Research interviews underway
+stack: SwiftUI, Core Data, Charts, CloudKit
+stats:
+  - label: Target teams
+    value: Cross-functional squads
+    description: Designed for product, ops, and engineering teams needing faster feedback loops.
+  - label: Ritual cadence
+    value: Under 10 minutes
+    description: Guided templates keep debrief capture lean without losing detail.
+  - label: Insight delivery
+    value: Automated summaries
+    description: Narrative reports and charts land in Slack and email immediately after sessions.
 nav:
   - id: overview
     label: Overview

--- a/projects/index.md
+++ b/projects/index.md
@@ -1,0 +1,4 @@
+---
+layout: projects
+permalink: /projects/
+---

--- a/projects/peaking.md
+++ b/projects/peaking.md
@@ -1,0 +1,57 @@
+title: Peaking
+type: App build
+summary: Daily readiness and periodisation planning for endurance athletes juggling work, family, and racing goals.
+role: Product & iOS Developer
+year: 2024
+order: 7
+platforms: iOS, watchOS
+status: Prototype in usability testing
+stack: SwiftUI, App Intents, HealthKit, Charts
+show_store_sections: true
+nav:
+  - id: overview
+    label: Overview
+  - id:readiness
+    label: Readiness model
+  - id:planning
+    label: Planning system
+  - id:roadmap
+    label: Roadmap
+stats:
+  - label: Feedback cadence
+    value: Daily check-ins
+    description: Two-question prompts capture subjective load in under 30 seconds.
+  - label: Automations
+    value: Health sync & widgets
+    description: HealthKit recovery signals drive App Intents routines and Lock Screen widgets.
+  - label: Target users
+    value: Busy amateurs
+    description: Designed around athletes balancing training with demanding jobs.
+---
+## Overview
+{: #overview .scroll-mt-32 }
+
+Peaking helps amateur endurance athletes plan smarter training blocks without a personal coach. The app layers a lightweight readiness score on top of structured periodisation templates so the right mix of intensity, skills, and recovery is always clear.
+
+I am using the project to test how App Intents and widgets can keep athletes accountable. Core health metrics such as heart rate variability and sleep are pulled directly from HealthKit while manual check-ins capture context that sensors miss.
+
+## Readiness model
+{: #readiness .scroll-mt-32 }
+
+- **Dual data streams**: Objective signals from HealthKit sit alongside qualitative prompts. The model highlights when perceived fatigue diverges from biometric recovery.
+- **Actionable insight**: Instead of opaque scores, Peaking presents plain-language guidance—train as planned, adjust duration, or pivot to technique work.
+- **Trend visibility**: Weekly retrospectives show how compliance and fatigue evolve, helping athletes and their support network spot overload early.
+
+## Planning system
+{: #planning .scroll-mt-32 }
+
+- **Block templates**: Athletes choose from proven 4- and 6-week periodisation templates tailored to triathlon, cycling, or running disciplines.
+- **Calendar integrations**: Workouts sync to Apple Calendar and Reminders so training sits alongside career and family commitments.
+- **Coach collaboration**: Shared plans allow remote coaches to tweak sessions, drop in notes, and review compliance metrics in real time.
+
+## Roadmap
+{: #roadmap .scroll-mt-32 }
+
+1. **Adaptive scheduling** – Auto-adjust sessions based on missed workouts and sleep debt.
+2. **Watch-first execution** – Build workout execution on watchOS with haptic cues and spoken instructions.
+3. **Team dashboards** – Provide aggregate compliance and recovery views for clubs and corporate wellness cohorts.

--- a/projects/ridge-runner-companion.md
+++ b/projects/ridge-runner-companion.md
@@ -4,6 +4,19 @@ summary: Building an offline-first hiking companion to test product release ritu
 role: Product & iOS Developer
 year: 2024 – Present
 order: 4
+platforms: iOS, watchOS
+status: Alpha release cadence
+stack: SwiftUI, Core Location, MapKit, CloudKit
+stats:
+  - label: Mission
+    value: Safer solo hikes
+    description: Deliver rapid readiness cues and actionable journalling for remote terrain.
+  - label: Quality practice
+    value: Release rituals
+    description: Every sprint runs through automated UI tests, smoke walks, and TestFlight notes.
+  - label: Offline focus
+    value: 100% field-ready
+    description: Critical data cached locally with background refresh to keep routes current.
 nav:
   - id: overview
     label: Overview

--- a/projects/squash-tracker.md
+++ b/projects/squash-tracker.md
@@ -1,0 +1,57 @@
+title: Squash Tracker
+type: App build
+summary: Rapid match capture and post-game analysis for competitive squash players training without a dedicated coaching staff.
+role: Product & iOS Developer
+year: 2024
+order: 6
+platforms: iOS, watchOS, visionOS (concept)
+status: TestFlight preparation
+stack: SwiftUI, Core Data, HealthKit, CloudKit
+show_store_sections: true
+nav:
+  - id: overview
+    label: Overview
+  - id:scoring
+    label: Match intelligence
+  - id:training
+    label: Training loops
+  - id:roadmap
+    label: Roadmap
+stats:
+  - label: Objective
+    value: Reduce admin to play
+    description: Capture a full match summary in under 45 seconds post-game.
+  - label: Automation
+    value: HealthKit sync
+    description: Pulls heart rate and calories from Apple Watch workouts to enrich stats.
+  - label: Coaching reach
+    value: Club players first
+    description: Designed for solo athletes and small training groups without analysts.
+---
+## Overview
+{: #overview .scroll-mt-32 }
+
+Squash Tracker packages the workflows I use with my own club into a native SwiftUI experience. Players set up fixtures in seconds, tag opponents, and capture scoring momentum without juggling paper scorecards. The app automates the admin that distracts from playing so the post-match review is ready before kit bags are packed.
+
+The build explores how far I can push on-device intelligence without a server. Core Data stores a player’s history locally while CloudKit keeps squads in sync across devices. Each release will add richer opponent profiling and experiment with lightweight coaching prompts.
+
+## Match intelligence
+{: #scoring .scroll-mt-32 }
+
+- **Point-by-point capture**: A watchOS companion lets scorers tap winners and forced errors courtside. The iOS app mirrors live momentum so teammates can follow along.
+- **Shot pattern tagging**: Quick gestures log serves, volleys, and back-court rallies. Tags roll up into heatmaps that highlight pressure zones.
+- **Auto-generated recaps**: Within 45 seconds of finishing a match, players receive a shareable summary showing run lengths, conversion rate under pressure, and stamina drift from HealthKit.
+
+## Training loops
+{: #training .scroll-mt-32 }
+
+- **Objectives to drills**: Training goals link directly to recorded weaknesses so the next solo or partner drill is preselected.
+- **Coach mode**: Shared insights allow mentors to leave timestamped feedback against individual rallies without needing full video footage.
+- **Season view**: Aggregate dashboards show form trends, endurance gains, and tactical improvements over a league campaign.
+
+## Roadmap
+{: #roadmap .scroll-mt-32 }
+
+1. **Club ladders** – Launch ranking boards with automatic notifications for challenge matches and expiry timers.
+2. **Computer vision ingest** – Experiment with visionOS to translate court-side captures into rally logs.
+3. **Video overlays** – Pair Apple Watch timestamps with synced video to highlight winning plays automatically.

--- a/projects/trainingplus.md
+++ b/projects/trainingplus.md
@@ -1,0 +1,57 @@
+title: TrainingPlus
+type: App build
+summary: A companion for Swift and SwiftUI learners that blends spaced repetition, coding challenges, and portfolio-ready mini projects.
+role: Product & iOS Developer
+year: 2024
+order: 8
+platforms: iOS, iPadOS, macOS (Catalyst)
+status: Content design in progress
+stack: SwiftUI, Combine, TipKit, CloudKit
+show_store_sections: true
+nav:
+  - id: overview
+    label: Overview
+  - id:learning
+    label: Learning experience
+  - id:content
+    label: Content pipeline
+  - id:roadmap
+    label: Roadmap
+stats:
+  - label: Curriculum
+    value: 40+ micro-lessons
+    description: Each anchored to a runnable Swift package with review prompts.
+  - label: Practice engine
+    value: Adaptive repetition
+    description: TipKit nudges learners back to topics when recall starts to fade.
+  - label: Community
+    value: Portfolio ready
+    description: Learners ship shareable mini projects with every module.
+---
+## Overview
+{: #overview .scroll-mt-32 }
+
+TrainingPlus exists to help self-taught developers turn scattered tutorials into a deliberate practice routine. The app orchestrates learning loops so every topic moves from passive reading to applied builds and peer review.
+
+Learners progress through micro-lessons on Swift fundamentals, SwiftUI patterns, and Apple platform APIs. Each module unlocks a focused coding challenge, discussion prompt, and optional stretch goal. CloudKit sync keeps progress consistent across iPhone, iPad, and Mac.
+
+## Learning experience
+{: #learning .scroll-mt-32 }
+
+- **Guided sprints**: Modules are grouped into weekly sprints with clear objectives, estimated effort, and reflection prompts.
+- **Adaptive review**: A spaced repetition engine surfaces flashcards and quiz questions when confidence drops, helping learners reinforce tricky concepts quickly.
+- **Demo days**: Learners can publish mini projects directly from the app to showcase progress and invite feedback from peers.
+
+## Content pipeline
+{: #content .scroll-mt-32 }
+
+- **Curriculum builder**: A macOS editor lets me design new lessons, author interactive explanations, and push updates via CloudKit without submitting a new binary.
+- **Community contributions**: Future versions will let trusted mentors contribute lessons that go through a lightweight review workflow.
+- **Analytics & support**: Opt-in analytics highlight where learners get stuck so I can prioritise new walkthroughs and office hours.
+
+## Roadmap
+{: #roadmap .scroll-mt-32 }
+
+1. **Mentor subscriptions** – Offer 1:1 support packages with scheduled check-ins and code reviews.
+2. **ARKit labs** – Introduce mixed-reality projects that blend spatial design with SwiftUI.
+3. **Certification prep** – Build mock exams and revision tracks aligned to Apple’s certification pathways.


### PR DESCRIPTION
## Summary
- introduce a dedicated projects layout with hero statistics, sticky navigation, and cards for case studies and app builds
- refresh the project detail template with home-page styling, back navigation, optional store links, and compliance sections
- add new Swift app build pages for Squash Tracker, Peaking, and TrainingPlus alongside updated metadata for existing builds

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68ea3fc0fbc08324bc40f7d27a0c1e3e