### PR TITLE
Remove scroll snapping styles from layouts

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html
   lang="en"
-  class="bg-charcoal-900 snap-y snap-mandatory scroll-pt-[5.5rem] sm:scroll-pt-[6.5rem] motion-reduce:snap-none"
+  class="bg-charcoal-900 scroll-pt-[5.5rem] sm:scroll-pt-[6.5rem]"
 >
   <head>
     {% include head.html %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -23,7 +23,7 @@ layout: default
 
 <section
   id="profile"
-  class="relative flex min-h-screen flex-col justify-center overflow-hidden border-b border-aluminum-500/20 bg-charcoal-900 snap-start"
+  class="relative flex min-h-screen flex-col justify-center overflow-hidden border-b border-aluminum-500/20 bg-charcoal-900"
 >
   <div class="mx-auto flex w-full max-w-5xl flex-col justify-center gap-10 px-6 py-24">
     <div class="space-y-6" data-animate="hero-copy">
@@ -107,7 +107,7 @@ layout: default
   </div>
 </nav>
 
-<section id="experience" class="nav-scroll-anchor flex min-h-screen flex-col justify-center border-b border-aluminum-500/20 bg-charcoal-900 snap-start">
+<section id="experience" class="nav-scroll-anchor flex min-h-screen flex-col justify-center border-b border-aluminum-500/20 bg-charcoal-900">
   <div class="mx-auto w-full max-w-5xl px-6 py-16">
     <div class="max-w-3xl space-y-4" data-animate="section-heading">
       <h2 class="text-3xl font-semibold text-aluminum-100">Experience</h2>
@@ -139,7 +139,7 @@ layout: default
   </div>
 </section>
 
-<section id="capabilities" class="nav-scroll-anchor flex min-h-screen flex-col justify-center border-b border-aluminum-500/20 bg-charcoal-900 snap-start">
+<section id="capabilities" class="nav-scroll-anchor flex min-h-screen flex-col justify-center border-b border-aluminum-500/20 bg-charcoal-900">
   <div class="mx-auto w-full max-w-5xl px-6 py-16">
     <div class="max-w-3xl space-y-4" data-animate="section-heading">
       <h2 class="text-3xl font-semibold text-aluminum-100">Core capabilities</h2>
@@ -158,7 +158,7 @@ layout: default
   </div>
 </section>
 
-<section id="education" class="nav-scroll-anchor flex min-h-screen flex-col justify-center border-b border-aluminum-500/20 bg-charcoal-900 snap-start">
+<section id="education" class="nav-scroll-anchor flex min-h-screen flex-col justify-center border-b border-aluminum-500/20 bg-charcoal-900">
   <div class="mx-auto w-full max-w-5xl px-6 py-16">
     <div class="max-w-3xl space-y-4" data-animate="section-heading">
       <h2 class="text-3xl font-semibold text-aluminum-100">Education &amp; Certifications</h2>
@@ -192,7 +192,7 @@ layout: default
   </div>
 </section>
 
-<section id="projects" class="nav-scroll-anchor flex min-h-screen flex-col justify-center border-b border-aluminum-500/20 bg-charcoal-900 snap-start">
+<section id="projects" class="nav-scroll-anchor flex min-h-screen flex-col justify-center border-b border-aluminum-500/20 bg-charcoal-900">
   <div class="mx-auto w-full max-w-5xl px-6 py-16">
     <div class="max-w-3xl space-y-4" data-animate="section-heading">
       <h2 class="text-3xl font-semibold text-aluminum-100">Projects &amp; case studies</h2>
@@ -256,7 +256,7 @@ layout: default
   </div>
 </section>
 
-<section id="contact" class="nav-scroll-anchor flex min-h-screen flex-col justify-center border-t border-aluminum-500/20 bg-charcoal-900 snap-start">
+<section id="contact" class="nav-scroll-anchor flex min-h-screen flex-col justify-center border-t border-aluminum-500/20 bg-charcoal-900">
   <div class="relative mx-auto w-full max-w-3xl px-6 py-20 text-center" data-animate="contact-wrapper">
     <div aria-hidden="true" class="pointer-events-none absolute inset-x-1/2 top-12 -z-10 h-64 w-[36rem] -translate-x-1/2 rounded-full bg-ember-400/20 blur-[120px] opacity-0" data-animate="contact-glow"></div>
     <h2 class="text-3xl font-semibold text-aluminum-100" data-animate="contact-heading">Let’s build momentum together</h2>


### PR DESCRIPTION
## Summary
- remove scroll snapping classes from the base layout to disable snap scrolling
- strip snap-start styles from home page sections so they no longer snap into view

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ebefb6b8248324b35b4da1e842a358