### PR TITLE
Refine project card interactions

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -202,9 +202,7 @@ layout: default
       {% if ordered_projects != empty %}
       <div class="grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
         {% for project in ordered_projects %}
-        <a class="group flex h-full flex-col justify-between surface-panel p-6 transition no-underline hover:no-underline focus-visible:no-underline"
-          data-animate="project-card"
-          href="{{ project.url | relative_url }}">
+        <article class="flex h-full flex-col justify-between surface-panel p-6" data-animate="project-card">
           <div class="space-y-4">
             <span class="inline-flex w-fit items-center rounded-full border border-aluminum-500/30 bg-aluminum-500/10 px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-aluminum-300">{{ project.type }}</span>
             <div class="space-y-2">
@@ -212,12 +210,11 @@ layout: default
               <p class="text-sm leading-relaxed text-aluminum-300">{{ project.summary }}</p>
             </div>
           </div>
-          <span class="mt-8 inline-flex items-center gap-2 text-sm font-medium text-aluminum-200">View project
-            <svg aria-hidden="true" class="h-4 w-4 transition group-hover:translate-x-1" data-animate="project-arrow" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
-              <path d="M5 12h14m-6-6 6 6-6 6" stroke-linecap="round" stroke-linejoin="round" />
-            </svg>
-          </span>
-        </a>
+          <a class="mt-8 inline-flex w-fit items-center justify-center rounded-full border border-aluminum-500/25 px-6 py-3 text-sm font-semibold text-aluminum-100 transition hover:border-ember-400/40 hover:bg-ember-500/10 no-underline hover:no-underline focus-visible:no-underline"
+            href="{{ project.url | relative_url }}">
+            View project
+          </a>
+        </article>
         {% endfor %}
       </div>
       {% else %}

--- a/assets/js/gsap-animations.js
+++ b/assets/js/gsap-animations.js
@@ -363,93 +363,28 @@
 
       if (!allowMotion) {
         gsapGlobal.set(cards, { y: 0, opacity: 1 });
-        const arrows = cards
-          .map((card) => card.querySelector('[data-animate="project-arrow"]'))
-          .filter(Boolean);
-        if (arrows.length) {
-          gsapGlobal.set(arrows, { x: 0, opacity: 1 });
-        }
         return;
       }
 
       cards.forEach((card) => {
-        const arrow = card.querySelector('[data-animate="project-arrow"]');
         gsapGlobal.set(card, { y: 48, opacity: 0, transformOrigin: '50% 50%' });
-        if (arrow) {
-          gsapGlobal.set(arrow, { x: 0, opacity: 0.6 });
-        }
-
-        const hoverTimeline = gsapGlobal
-          .timeline({
-            paused: true,
-            defaults: { ease: 'power2.out' },
-          })
-          .to(
-            card,
-            {
-              y: -12,
-              scale: 1.02,
-              boxShadow: '0 28px 55px -30px rgba(255, 176, 122, 0.6)',
-              duration: 0.35,
-            },
-            0
-          );
-
-        if (arrow) {
-          hoverTimeline
-            .to(
-              arrow,
-              {
-                x: 16,
-                duration: 0.18,
-              },
-              0
-            )
-            .to(
-              arrow,
-              {
-                x: 8,
-                duration: 0.24,
-                ease: 'power1.out',
-              },
-              '>-0.05'
-            );
-        }
 
         const animateIn = () => {
-          hoverTimeline.progress(0).pause();
           gsapGlobal.to(card, {
             y: 0,
             opacity: 1,
             duration: 0.6,
             ease: 'power1.out',
           });
-          if (arrow) {
-            gsapGlobal.to(arrow, {
-              x: 8,
-              opacity: 1,
-              duration: 0.5,
-              ease: 'power1.out',
-            });
-          }
         };
 
         const resetState = () => {
-          hoverTimeline.progress(0).pause();
           gsapGlobal.to(card, {
             y: 48,
             opacity: 0,
             duration: 0.4,
             ease: 'power1.in',
           });
-          if (arrow) {
-            gsapGlobal.to(arrow, {
-              x: 0,
-              opacity: 0.6,
-              duration: 0.3,
-              ease: 'power1.in',
-            });
-          }
         };
 
         ScrollTrigger.create({
@@ -461,14 +396,6 @@
           onLeave: resetState,
           onLeaveBack: resetState,
         });
-
-        const playHover = () => hoverTimeline.play();
-        const resetHover = () => hoverTimeline.reverse();
-
-        card.addEventListener('mouseenter', playHover);
-        card.addEventListener('mouseleave', resetHover);
-        card.addEventListener('focusin', playHover);
-        card.addEventListener('focusout', resetHover);
       });
     }
 


### PR DESCRIPTION
## Summary
- convert project cards to static panels with a dedicated secondary-style "View project" button link
- remove the GSAP hover timeline so project cards no longer scale or cast a glow on hover while keeping scroll-in animation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ecf275f5b48324b024081d8fab195e