### PR TITLE
Fix project project sections layout activation

### DIFF
--- a/assets/js/page-nav.js
+++ b/assets/js/page-nav.js
@@ -143,6 +143,16 @@
         });
       }
 
+      function refreshNav({ immediate = false } = {}) {
+        updateSectionOffsets();
+        const trigger = () => handleScroll({ fromHash: true });
+        if (immediate) {
+          trigger();
+        } else {
+          window.requestAnimationFrame(trigger);
+        }
+      }
+
       updateSectionOffsets();
       handleScroll({ fromHash: true });
 
@@ -155,9 +165,16 @@
       );
 
       window.addEventListener('resize', () => {
-        updateSectionOffsets();
-        window.requestAnimationFrame(() => handleScroll({ fromHash: true }));
+        refreshNav();
       });
+
+      nav.addEventListener('nav:refresh', () => {
+        refreshNav();
+      });
+
+      if (document.documentElement.dataset.projectSectionsReady === 'true') {
+        refreshNav({ immediate: true });
+      }
 
       if (window.location.hash) {
         const hashId = window.location.hash.slice(1);
@@ -178,6 +195,12 @@
           window.requestAnimationFrame(handleScroll);
         });
       });
+    });
+  });
+
+  document.addEventListener('projectSections:ready', () => {
+    document.querySelectorAll('[data-sticky-nav]').forEach((nav) => {
+      nav.dispatchEvent(new CustomEvent('nav:refresh'));
     });
   });
 })();

--- a/assets/js/project-sections.js
+++ b/assets/js/project-sections.js
@@ -7,6 +7,20 @@
     }
   }
 
+  function getHeadings(container) {
+    if (!container || !container.children) {
+      return [];
+    }
+
+    return Array.from(container.children).filter((child) => {
+      return (
+        child.nodeType === Node.ELEMENT_NODE &&
+        child.matches &&
+        child.matches('h2.nav-scroll-anchor')
+      );
+    });
+  }
+
   function collectFollowingNodes(start) {
     const nodes = [];
     let node = start;
@@ -87,9 +101,7 @@
       return;
     }
 
-    const headings = Array.from(
-      container.querySelectorAll(':scope > h2.nav-scroll-anchor')
-    );
+    const headings = getHeadings(container);
 
     if (!headings.length) {
       return;
@@ -101,6 +113,16 @@
 
     container.dataset.projectSectionsReady = 'true';
     container.classList.add('project-sections-ready');
+    document.documentElement.dataset.projectSectionsReady = 'true';
     removeEmptyTextNodes(container);
+
+    document.dispatchEvent(
+      new CustomEvent('projectSections:ready', {
+        detail: {
+          container,
+          sectionCount: getHeadings(container).length,
+        },
+      })
+    );
   });
 })();


### PR DESCRIPTION
## Summary
- ensure the project sections script builds sections without relying on :scope selectors and notifies the document when ready
- refresh sticky navigation offsets whenever dynamically generated sections are prepared

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68ecf802faa08324b8d2920f1ecc8c7f