### PR TITLE
Remove footer minimum height

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,7 +16,7 @@
       {{ content }}
     </main>
 
-    <footer class="border-t border-aluminum-500/25 bg-charcoal-900 min-h-[50vh]">
+    <footer class="border-t border-aluminum-500/25 bg-charcoal-900">
       <div class="mx-auto flex w-full max-w-5xl flex-col gap-4 px-6 py-10 text-sm text-aluminum-400">
         <div class="flex flex-wrap items-center gap-3">
           <p>© {{ 'now' | date: '%Y' }} {{ site.title }}</p>


### PR DESCRIPTION
## Summary
- remove the min-height utility from the footer so it no longer has a forced minimum height

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ee07087fc8832489fa8d2e7f2bcf4d