### PR TITLE
Adjust nav scroll padding for docking

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -76,7 +76,7 @@ layout: default
   data-dock-target="profile"
 >
   <div class="mx-auto w-full max-w-5xl">
-    <div class="relative flex gap-3 overflow-x-auto px-6 py-4 text-sm" data-nav-scroll>
+    <div class="relative flex gap-3 overflow-x-auto px-6 pt-4 pb-5 text-sm" data-nav-scroll>
       <a class="relative z-10 whitespace-nowrap rounded-full border border-transparent px-4 py-2 font-medium text-aluminum-300 transition hover:text-aluminum-100 hover:border-aluminum-500/40 aria-[current=page]:border-ember-400/50 aria-[current=page]:bg-ember-500/10 aria-[current=page]:text-ember-200 aria-[current=page]:texture-noise no-underline hover:no-underline focus-visible:no-underline"
         href="#experience"
         data-nav-link


### PR DESCRIPTION
## Summary
- replace the sticky nav scroll container padding with an asymmetric top/bottom combo so the pill border clears the viewport edge when docked

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68ee0e405e588324bcd8bcdb970b8008