### PR TITLE
Adjust section nav activation threshold

### DIFF
--- a/assets/js/page-nav.js
+++ b/assets/js/page-nav.js
@@ -192,21 +192,18 @@
 
       function getActiveItemId() {
         let lastReachedId = null;
+        const activationThreshold = 1;
 
         linkItems.forEach(({ section }) => {
           const rect = section.getBoundingClientRect();
           const scrollOffset = parseFloat(section.dataset.navScrollOffset || '0') || 0;
 
-          if (rect.top - scrollOffset <= 1) {
+          if (rect.top - scrollOffset <= -activationThreshold) {
             lastReachedId = section.id;
           }
         });
 
-        if (lastReachedId) {
-          return lastReachedId;
-        }
-
-        return linkItems.length ? linkItems[0].section.id : null;
+        return lastReachedId;
       }
 
       function handleScroll({ fromHash = false } = {}) {


### PR DESCRIPTION
## Summary
- delay section nav active state until its content is scrolled into view by requiring a small offset before marking reached sections
- avoid forcing the first section link to appear active before the reader scrolls

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ee0fdac3288324a719e2f3e26b8d8f