### PR TITLE
Fix sticky nav activation offsets

### DIFF
--- a/assets/js/page-nav.js
+++ b/assets/js/page-nav.js
@@ -193,14 +193,31 @@
       function getActiveItemId() {
         let lastReachedId = null;
         const activationThreshold = 1;
+        const navHeight = nav.offsetHeight;
+        const viewportHeight =
+          window.innerHeight || document.documentElement.clientHeight || 0;
 
-        linkItems.forEach(({ section }) => {
+        linkItems.forEach(({ section }, index) => {
           const rect = section.getBoundingClientRect();
           const scrollOffset = parseFloat(section.dataset.navScrollOffset || '0') || 0;
+          const hasReachedAnchor = rect.top - scrollOffset <= -activationThreshold;
 
-          if (rect.top - scrollOffset <= -activationThreshold) {
+          if (index === 0) {
+            const intersectsViewport =
+              rect.bottom > navHeight + activationThreshold &&
+              rect.top < viewportHeight - activationThreshold;
+
+            if (intersectsViewport || hasReachedAnchor) {
+              lastReachedId = section.id;
+            }
+
+            return;
+          }
+
+          if (hasReachedAnchor) {
             lastReachedId = section.id;
           }
+        });
 
         return lastReachedId;
       }


### PR DESCRIPTION
## Summary
- repair the in-page navigation script so it calculates active sections without throwing a syntax error
- activate the first section when it enters the viewport and align subsequent activations with the sticky offset used for scrolling

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ee1eaa52688324bb3128782d0ca725