### PR TITLE
Fix sticky nav activation tolerance

### DIFF
--- a/assets/js/page-nav.js
+++ b/assets/js/page-nav.js
@@ -200,7 +200,7 @@
         linkItems.forEach(({ section }, index) => {
           const rect = section.getBoundingClientRect();
           const scrollOffset = parseFloat(section.dataset.navScrollOffset || '0') || 0;
-          const hasReachedAnchor = rect.top - scrollOffset <= -activationThreshold;
+          const hasReachedAnchor = rect.top - scrollOffset <= activationThreshold;
 
           if (index === 0) {
             const intersectsViewport =


### PR DESCRIPTION
## Summary
- adjust the sticky navigation activation check so sections become active as soon as their anchor is reached

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68ee218863dc8324a5813a3bddc615cb