### PR TITLE
Adjust sticky nav docking threshold

### DIFF
--- a/assets/js/page-nav.js
+++ b/assets/js/page-nav.js
@@ -142,7 +142,10 @@
 
         const heroRect = dockTarget.getBoundingClientRect();
         const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
-        const shouldDock = heroRect.top < viewportHeight && heroRect.bottom > viewportHeight;
+        const navHeight = nav.offsetHeight || 0;
+        const dockThreshold = Math.max(viewportHeight - navHeight, 0);
+        const shouldDock =
+          heroRect.top >= 0 && heroRect.top < viewportHeight && heroRect.bottom > dockThreshold;
         applyDockState(shouldDock);
       }
 


### PR DESCRIPTION
## Summary
- update sticky nav docking logic to consider the nav height when comparing the hero target bounds
- ensure the docked state ends when the hero no longer occupies the viewport bottom threshold

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ee453fb40c83248f7b5251b58c39cf