### PR TITLE
Refine contact section animations

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -229,7 +229,11 @@ layout: default
 </section>
 
 <section id="contact" class="nav-scroll-anchor flex min-h-screen flex-col justify-center border-t border-aluminum-500/20 bg-charcoal-900">
-  <div class="relative mx-auto w-full max-w-3xl px-6 py-20 text-center" data-animate="contact-wrapper">
+  <div
+    class="relative mx-auto w-full max-w-3xl px-6 py-20 text-center"
+    data-animate="contact-wrapper"
+    data-spotlight="static"
+  >
     <div aria-hidden="true" class="pointer-events-none absolute inset-x-1/2 top-12 -z-10 h-64 w-[36rem] -translate-x-1/2 rounded-full bg-ember-400/20 blur-[120px] opacity-0" data-animate="contact-glow"></div>
     <h2 class="text-3xl font-semibold text-aluminum-100" data-animate="contact-heading">Let’s build momentum together</h2>
     <p class="mt-6 text-lg text-aluminum-300" data-animate="contact-copy">

--- a/assets/js/gsap-animations.js
+++ b/assets/js/gsap-animations.js
@@ -8,7 +8,9 @@
   }
 
   function initCardSpotlight() {
-    const cards = Array.from(document.querySelectorAll('.surface-panel'));
+    const cards = Array.from(document.querySelectorAll('.surface-panel')).filter(
+      (card) => card.dataset.spotlight !== 'static'
+    );
     if (!cards.length) {
       return;
     }
@@ -351,10 +353,9 @@
         return;
       }
 
-      animateCardStack(wrapper, {
-        start: 'top 80%',
-        end: 'bottom 25%',
-      });
+      if (wrapper) {
+        gsapGlobal.set(wrapper, { y: 48, opacity: 0 });
+      }
 
       if (glow) {
         gsapGlobal.set(glow, { opacity: 0, scale: 0.7, transformOrigin: '50% 50%' });
@@ -378,6 +379,10 @@
           toggleActions: 'play none none reverse',
         },
       });
+
+      if (wrapper) {
+        contactTimeline.to(wrapper, { y: 0, opacity: 1, duration: 0.6 }, 0);
+      }
 
       if (glow) {
         contactTimeline.to(glow, { opacity: 1, scale: 1.05, duration: 0.8 }, 0);


### PR DESCRIPTION
## Summary
- allow surface panels to opt out of the interactive spotlight effect and mark the contact wrapper as static
- drive the contact section reveal with a dedicated timeline instead of the shared card stack helper

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ee4a3401d88324a445b745a4a6882d