### PR TITLE
Wrap contact section in surface card

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -229,26 +229,24 @@ layout: default
 </section>
 
 <section id="contact" class="nav-scroll-anchor flex min-h-screen flex-col justify-center border-t border-aluminum-500/20 bg-charcoal-900">
-  <div
-    class="relative mx-auto w-full max-w-3xl px-6 py-20 text-center"
-    data-animate="contact-wrapper"
-    data-spotlight="static"
-  >
-    <div aria-hidden="true" class="pointer-events-none absolute inset-x-1/2 top-12 -z-10 h-64 w-[36rem] -translate-x-1/2 rounded-full bg-ember-400/20 blur-[120px] opacity-0" data-animate="contact-glow"></div>
-    <h2 class="text-3xl font-semibold text-aluminum-100" data-animate="contact-heading">Let’s build momentum together</h2>
-    <p class="mt-6 text-lg text-aluminum-300" data-animate="contact-copy">
-      Whether you need to stabilise release operations, evolve complex training programmes, or unite teams behind a shared roadmap, Liam can help you deliver with confidence.
-    </p>
-    <div class="mt-10 flex flex-wrap justify-center gap-4" data-animate="contact-actions">
-      <a class="inline-flex items-center justify-center rounded-full bg-ember-400 px-6 py-3 text-sm font-semibold text-charcoal-950 transition texture-noise hover:bg-ember-300"
-        data-animate="contact-cta"
-        href="mailto:{{ site.contact.email }}">
-        Book a call
-      </a>
-      <a class="inline-flex items-center justify-center rounded-full border border-aluminum-500/25 px-6 py-3 text-sm font-semibold text-aluminum-100 transition hover:border-ember-400/40 hover:bg-ember-500/10"
-        href="{{ site.contact.linkedin }}">
-        Connect on LinkedIn
-      </a>
+  <div class="mx-auto w-full max-w-3xl px-6 py-20" data-animate="contact-wrapper" data-spotlight="static">
+    <div class="surface-panel relative overflow-hidden px-8 py-12 text-center shadow-[0_20px_45px_-30px_rgba(0,0,0,0.9)]">
+      <div aria-hidden="true" class="pointer-events-none absolute inset-x-1/2 top-12 -z-10 h-64 w-[36rem] -translate-x-1/2 rounded-full bg-ember-400/20 blur-[120px] opacity-0" data-animate="contact-glow"></div>
+      <h2 class="text-3xl font-semibold text-aluminum-100" data-animate="contact-heading">Let’s build momentum together</h2>
+      <p class="mt-6 text-lg text-aluminum-300" data-animate="contact-copy">
+        Whether you need to stabilise release operations, evolve complex training programmes, or unite teams behind a shared roadmap, Liam can help you deliver with confidence.
+      </p>
+      <div class="mt-10 flex flex-wrap justify-center gap-4" data-animate="contact-actions">
+        <a class="inline-flex items-center justify-center rounded-full bg-ember-400 px-6 py-3 text-sm font-semibold text-charcoal-950 transition texture-noise hover:bg-ember-300"
+          data-animate="contact-cta"
+          href="mailto:{{ site.contact.email }}">
+          Book a call
+        </a>
+        <a class="inline-flex items-center justify-center rounded-full border border-aluminum-500/25 px-6 py-3 text-sm font-semibold text-aluminum-100 transition hover:border-ember-400/40 hover:bg-ember-500/10"
+          href="{{ site.contact.linkedin }}">
+          Connect on LinkedIn
+        </a>
+      </div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- wrap the contact section content in a `surface-panel` container so it matches the card styling used elsewhere on the page
- retain the existing glow accent and calls-to-action inside the new card layout for a consistent presentation

## Testing
- bundle exec jekyll serve --livereload --host 0.0.0.0 --port 4000

------
https://chatgpt.com/codex/tasks/task_e_68ee5a0ddc608324bf03b9040b1608ef