### PR TITLE
Align contact card styling with shared panels

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -229,9 +229,8 @@ layout: default
 </section>
 
 <section id="contact" class="nav-scroll-anchor flex min-h-screen flex-col justify-center border-t border-aluminum-500/20 bg-charcoal-900">
-  <div class="mx-auto w-full max-w-3xl px-6 py-20" data-animate="contact-wrapper" data-spotlight="static">
-    <div class="surface-panel relative overflow-hidden px-8 py-12 text-center shadow-[0_20px_45px_-30px_rgba(0,0,0,0.9)]">
-      <div aria-hidden="true" class="pointer-events-none absolute inset-x-1/2 top-12 -z-10 h-64 w-[36rem] -translate-x-1/2 rounded-full bg-ember-400/20 blur-[120px] opacity-0" data-animate="contact-glow"></div>
+  <div class="mx-auto w-full max-w-3xl px-6 py-20" data-animate="contact-wrapper">
+    <div class="surface-panel px-8 py-12 text-center">
       <h2 class="text-3xl font-semibold text-aluminum-100" data-animate="contact-heading">Let’s build momentum together</h2>
       <p class="mt-6 text-lg text-aluminum-300" data-animate="contact-copy">
         Whether you need to stabilise release operations, evolve complex training programmes, or unite teams behind a shared roadmap, Liam can help you deliver with confidence.


### PR DESCRIPTION
## Summary
- remove the contact section's static spotlight effect and extra wrapper styling
- rely on the base surface panel styling so the card matches the rest of the layout while retaining hover states

## Testing
- bundle exec jekyll serve --host 0.0.0.0 --port 4000

------
https://chatgpt.com/codex/tasks/task_e_68ee601762cc8324a5f7425d98c4aac0