### PR TITLE
Split military experience into individual roles with civilian titles

### DIFF
--- a/_data/cv.yml
+++ b/_data/cv.yml
@@ -60,8 +60,8 @@ employment:
       - Active contributor to agile sprint ceremonies — planning, backlog refinement, reviews and retrospectives — working alongside engineering, design and QA to maintain delivery momentum.
       - Provides second-line technical support for B2C users, maintaining direct contact with consumer pain points and feeding insights into product prioritisation — reducing inbound support volume by 19% year-on-year.
 
-  - title: Product Manager & Operations Manager
-    company: British Army
+  - title: Product Manager & Programme Manager
+    company: British Army — Combat CIS School
     location: Dorset, UK
     period: Jul 2020 – Sep 2023
     highlights:
@@ -71,15 +71,30 @@ employment:
       - Managed a cross-functional team of 12, running weekly stand-ups, sprint reviews and retrospectives aligned to agile principles in a regulated, security-sensitive environment.
       - Produced business cases, roadmaps and risk registers to secure Director-level investment approval; managed programme budget and resource allocation throughout delivery.
 
-  - title: Operations Officer & Signals Officer
+  - title: Technical Coordinator
     company: British Army — 1st Bn Duke of Lancaster's Regiment
-    location: Chester, UK · Cyprus
-    period: Sep 2013 – Jul 2020
+    location: Chester, UK
+    period: Jul 2018 – Jul 2020
     highlights:
-      - Served as Regimental Signals Officer and Company Operations Officer across successive postings, coordinating cross-functional planning for exercises and deployments of up to 500 personnel.
-      - Managed and maintained full accountability for £3M of serialised equipment across complex international deployments (Kenya, Jordan, USA), achieving 100% readiness throughout.
-      - Designed and delivered structured training programmes for 100+ personnel, using performance data and after-action reviews to iterate and improve outcomes.
-      - Commanded a 30-person platoon on operational deployments, accountable for team performance, risk management and mission execution under time-critical conditions.
+      - Coordinated secure communications infrastructure across a regiment of 500+ personnel, ensuring seamless operational connectivity during exercises and international deployments including Kenya.
+      - Increased trained communication specialists from 2 to 8 per 30-person team, significantly enhancing unit operational capability and readiness.
+      - Maintained 100% compliance with cryptographic material security protocols, achieving an incident-free reporting period across both years of responsibility.
+
+  - title: Operations Officer
+    company: British Army — 1st Bn Duke of Lancaster's Regiment
+    location: Cyprus
+    period: Jul 2016 – Jul 2018
+    highlights:
+      - Ensured the training readiness of 130 personnel for consecutive international deployments to the USA, Kenya and Jordan, managing compliance with critical safety certifications.
+      - Managed and maintained full accountability for £3M of serialised equipment across complex international deployments, achieving 100% operational readiness throughout.
+
+  - title: Team Leader
+    company: British Army — 1st Bn Duke of Lancaster's Regiment
+    location: Cyprus
+    period: Jul 2014 – Jul 2016
+    highlights:
+      - Led a 30-person team on operational duties, accountable for performance, welfare and development across four seniority levels.
+      - Managed the transition of operational role and reintegration from overseas to the UK, coordinating training and certification updates to meet new requirements.
 
 education:
   - qualification: MBA, Technology Management (in progress)
@@ -163,8 +178,8 @@ variants:
           - Active contributor to agile sprint ceremonies (planning, backlog refinement, reviews, retrospectives) working alongside engineering, design and QA to maintain delivery momentum.
           - Supported go-to-market coordination for product launches and partner integrations, working across sales, marketing and engineering for successful rollouts to 200+ partner organisations.
           - Provides second-line technical support for B2C users, maintaining direct contact with consumer pain points and reducing inbound support volume by 19% year-on-year.
-      - title: Product Manager & Operations Manager
-        company: British Army
+      - title: Product Manager & Programme Manager
+        company: British Army — Combat CIS School
         location: Dorset, UK
         period: Jul 2020 – Sep 2023
         highlights:
@@ -173,14 +188,28 @@ variants:
           - Increased student output by 30% through data-driven redesign, applying analytics and feedback loops to identify bottlenecks and optimise outcomes.
           - Managed a cross-functional team of 12, running weekly stand-ups, sprint reviews and retrospectives aligned to agile principles in a regulated environment.
           - Translated complex requirements into a prioritised product backlog, liaising with engineering partners and Director-level stakeholders to maintain strategic alignment.
-      - title: Operations Officer & Platoon Commander
+      - title: Technical Coordinator
         company: British Army — 1st Bn Duke of Lancaster's Regiment
-        location: Chester, UK · Cyprus
-        period: Sep 2013 – Jul 2020
+        location: Chester, UK
+        period: Jul 2018 – Jul 2020
         highlights:
-          - Coordinated cross-functional planning for exercises and deployments of up to 500 personnel as Operations Officer at regimental headquarters.
-          - Commanded a 30-person platoon on operational deployments, accountable for team performance, risk management and mission execution under time-critical conditions.
-          - Designed and delivered training programmes for 100+ personnel, using performance data and after-action reviews to continuously iterate and improve outcomes.
+          - Managed communications infrastructure across a 500+ person organisation, coordinating cross-functional planning to ensure operational readiness during international exercises and deployments.
+          - Designed and delivered training programmes that increased specialist capability from 2 to 8 per 30-person team, using performance data to iterate and improve outcomes.
+          - Maintained 100% compliance with security protocols, delivering an incident-free reporting period across both years of responsibility.
+      - title: Operations Officer
+        company: British Army — 1st Bn Duke of Lancaster's Regiment
+        location: Cyprus
+        period: Jul 2016 – Jul 2018
+        highlights:
+          - Coordinated training readiness for 130 personnel across consecutive international deployments to the USA, Kenya and Jordan, managing compliance with critical safety certifications.
+          - Managed £3M of serialised equipment across complex international deployments, maintaining 100% accountability and operational readiness.
+      - title: Team Leader
+        company: British Army — 1st Bn Duke of Lancaster's Regiment
+        location: Cyprus
+        period: Jul 2014 – Jul 2016
+        highlights:
+          - Commanded a 30-person team, accountable for performance, risk management and mission execution under time-critical conditions.
+          - Managed the operational transition and reintegration from overseas to the UK, coordinating training and certification updates.
 
   defence:
     hero_badge: "Product Manager · Defence & Government"
@@ -222,8 +251,8 @@ variants:
       - title: Security Clearance
         description: Holds active UK government security clearance — details available on request — enabling immediate engagement on sensitive and regulated programmes.
     employment:
-      - title: Product Manager & Operations Manager
-        company: British Army
+      - title: Product Manager & Programme Manager
+        company: British Army — Combat CIS School
         location: Dorset, UK
         period: Jul 2020 – Sep 2023
         highlights:
@@ -232,15 +261,29 @@ variants:
           - Increased student output by 30% through data-driven curriculum redesign, applying analytics and structured feedback loops to identify bottlenecks and optimise outcomes.
           - Translated complex technical and operational requirements into a prioritised product backlog, maintaining alignment between engineering partners and Director-level stakeholders throughout.
           - Produced business cases, roadmaps and risk registers to secure investment approval; managed programme budget and resource allocation throughout the delivery lifecycle.
-      - title: Operations Officer & Signals Officer
+      - title: Technical Coordinator
         company: British Army — 1st Bn Duke of Lancaster's Regiment
-        location: Chester, UK · Cyprus
-        period: Sep 2013 – Jul 2020
+        location: Chester, UK
+        period: Jul 2018 – Jul 2020
         highlights:
           - Served as Regimental Signals Officer responsible for secure communications infrastructure and cryptographic material compliance across a regiment of 500+ personnel.
-          - Coordinated cross-functional operational planning as Operations Officer at regimental headquarters, spanning logistics, intelligence and command elements.
-          - Managed and maintained 100% accountability for £3M of serialised equipment across international deployments to Kenya, Jordan and the USA.
-          - Commanded a 30-person platoon on operational deployments, accountable for team performance, risk management and mission execution under time-critical conditions.
+          - Achieved a gold standard in facilitating operational coordination during key assessment activities in Kenya, ensuring seamless and secure communications across all operational areas.
+          - Increased trained communication specialists from 2 to 8 per 30-person team, significantly enhancing unit operational capabilities and readiness.
+          - Maintained 100% compliance with cryptographic material security protocols, achieving an incident-free reporting period across both years of responsibility.
+      - title: Operations Officer
+        company: British Army — 1st Bn Duke of Lancaster's Regiment
+        location: Cyprus
+        period: Jul 2016 – Jul 2018
+        highlights:
+          - Ensured the training readiness of 130 soldiers for consecutive deployments to the USA, Kenya and Jordan, managing compliance with critical risk-to-life certifications including weapons handling and combat first aid.
+          - Managed and maintained full accountability for £3M of serialised equipment across complex international deployments, achieving 100% operational readiness under challenging conditions.
+      - title: Team Leader
+        company: British Army — 1st Bn Duke of Lancaster's Regiment
+        location: Cyprus
+        period: Jul 2014 – Jul 2016
+        highlights:
+          - Led a 30-person platoon on operational duties, accountable for team performance, welfare, risk management and mission execution.
+          - Managed the change in operational role and reintegration from Cyprus to the UK, coordinating training and certification updates to meet new operational requirements.
       - title: Technical Product Specialist
         company: Outdooractive
         location: Remote (Cambridge, UK · Immenstadt, Germany)


### PR DESCRIPTION
## Summary
- Breaks the consolidated 1LANCS entry (2013–2020) into three individual roles: **Technical Coordinator**, **Operations Officer**, and **Team Leader**
- Updates the Dorset role title to **Product Manager & Programme Manager** and company to **British Army — Combat CIS School**
- Applied consistently across all three CV variants (default, PM, defence) with variant-appropriate highlights

## Test plan
- [ ] Verify default variant renders all five experience entries correctly
- [ ] Verify PM variant (`?variant=pm`) shows updated roles
- [ ] Verify defence variant (`?variant=defence`) shows updated roles with Outdooractive still listed last

🤖 Generated with [Claude Code](https://claude.com/claude-code)