### PR TITLE
Add GitHub profile link to site (config, contact section, footer)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -54,7 +54,7 @@ nav_links:
 social:
   email: liam@liamday.co.uk
   linkedin: https://www.linkedin.com/in/liammday/
-  github:
+  github: https://github.com/liammday
   medium:
 
 contact:

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -232,6 +232,12 @@ layout: default
         href="{{ site.contact.linkedin }}">
         Connect on LinkedIn
       </a>
+      {% if site.social.github %}
+      <a class="inline-flex items-center justify-center rounded-full border border-aluminum-500/25 px-6 py-3 text-sm font-semibold text-aluminum-100 transition hover:border-ember-400/40 hover:bg-ember-500/10"
+        href="{{ site.social.github }}">
+        View on GitHub
+      </a>
+      {% endif %}
     </div>
   </div>
 </section>


### PR DESCRIPTION
Populated the existing blank social.github field in _config.yml and added a View on GitHub button to the contact section CTA row. The footer GitHub link was already conditional and now renders automatically.