### PR TITLE
peaking: add compatibility section + correct project tile

### DIFF
--- a/_data/app_projects.yml
+++ b/_data/app_projects.yml
@@ -31,7 +31,7 @@
     - Charts
   features:
     - Interactive peak discovery map with clustering, filtering, and rich metadata.
-    - Route imports from HealthKit, Strava, and GPX with automated summit matching.
+    - Route imports from Apple HealthKit (Apple Watch primary, with bridge-app support for Garmin / Polar / Suunto via HealthFit or RunGap) and Strava, with automated summit matching and GPX export for portability.
     - Published and user-created collections (for example Munros and Wainwrights) with completion tracking.
     - Offline-first cache layers for map tiles and peak data with cloud-synced personal progress.
 

--- a/peaking.md
+++ b/peaking.md
@@ -14,6 +14,24 @@ Peaking is an iOS app in private beta. It takes your activity history from Apple
 - Shows you what you've climbed, what's near, and what's next — on a clean, fast map.
 - Pulls route data from **Apple HealthKit** or **Strava**, with your permission. Everything is stored on your device and, if you use iCloud, in your own private iCloud account. No server. No analytics. No ads.
 
+## Which devices and apps work?
+
+Peaking matches your walks against peaks using the GPS route attached to each workout in Apple Health. Not every fitness device writes that route, so it's worth knowing before you sign up.
+
+**Works today (route flows through to Peaking):**
+
+- **Apple Watch** — outdoor walking, running, hiking and cycling workouts. The canonical happy path.
+- **Third-party iOS recording apps** that write routes to Apple Health — Strava (when you record in Strava itself), Nike Run Club, Footpath, WorkOutDoors and similar.
+- **Photos with location** — geotagged photos are suggested as Photo Summits automatically.
+
+**Doesn't work directly (the route doesn't reach Apple Health):**
+
+Garmin Connect, COROS, Polar Flow, Suunto, Wahoo, Fitbit, AllTrails, Komoot. Each vendor's Apple Health integration is summary-only — distance, time, heart rate — but no GPS route.
+
+**Rescue path for Garmin / Polar / Suunto users:** the iOS bridge apps **HealthFit** and **RunGap** pull the original workout file from your vendor's cloud and rewrite it into Apple Health with the route intact. Peaking can then match those exactly like an Apple Watch workout.
+
+Direct Strava OAuth (independent of Apple Health) is in development and gated on Strava API approval.
+
 ## Privacy
 
 See the [Peaking privacy policy](/peaking/privacy/) for full detail on what data the app handles, where it lives, and how to delete it.


### PR DESCRIPTION
## Summary

Two changes to make the /peaking/ surface more accurate for prospective testers reading the site before signing up to the TestFlight beta.

### 1. `peaking.md` — add "Which devices and apps work?" section

The existing page only said "Pulls route data from Apple HealthKit or Strava" — accurate but vague. A reader with a Garmin can't tell whether their workouts will work. Adds a compact compatibility section listing:

- ✅ Apple Watch, third-party iOS recording apps that write routes to Apple Health, geotagged photos
- ❌ Garmin Connect, COROS, Polar Flow, Suunto, Wahoo, Fitbit, AllTrails, Komoot — vendor integrations are summary-only, no route
- 🔧 Rescue path for Garmin / Polar / Suunto users: the **HealthFit** and **RunGap** iOS bridge apps

### 2. `_data/app_projects.yml` — correct the project tile

Line 34 previously claimed: *"Route imports from HealthKit, Strava, and GPX with automated summit matching."*

GPX is **export-only** in Peaking — there's a `GPXExporter.swift` but no importer. Corrected to: *"Route imports from Apple HealthKit (Apple Watch primary, with bridge-app support for Garmin / Polar / Suunto via HealthFit or RunGap) and Strava, with automated summit matching and GPX export for portability."*

## Source of truth

Content tracks the authoritative reference doc in the Peaking repo: [`Docs/Comms/HealthKitCompatibilityReference.md`](https://github.com/liammday/Peaking/blob/main/Docs/Comms/HealthKitCompatibilityReference.md) (added by liammday/Peaking#2247). When that file changes, this page should follow.

## Test plan

- [x] Markdown / YAML only, no template changes
- [x] All vendor names cross-referenced against the reference doc
- [ ] Local Jekyll build to confirm no rendering regressions on `/peaking/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)