### PR TITLE
chore(ci): bump GitHub Pages workflow actions to Node 24 versions

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -27,11 +27,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"
@@ -45,7 +45,7 @@ jobs:
           source: ./
           destination: ./_site
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
 
   # Deployment job
   deploy:
@@ -57,4 +57,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary
Clears the Node 20 deprecation warnings that appeared in the last deploy by bumping the workflow's actions to their current (Node 24) majors.

| Action | Before | After | Runtime |
|---|---|---|---|
| actions/checkout | v4 | **v6** | node24 |
| actions/configure-pages | v5 | **v6** | node24 |
| actions/setup-node | v4 | **v6** | node24 |
| actions/upload-pages-artifact | v3 | **v5** | composite (path default still `_site/`) |
| actions/deploy-pages | v4 | **v5** | node24 |

`actions/jekyll-build-pages@v1` is left as-is (latest v1.0.13; not Node-deprecated).

## Verification
- Each target version's `runs.using` confirmed `node24` (or composite) via the actions' `action.yml`.
- `upload-pages-artifact@v5` path input still defaults to `_site/`, so the upload step is unaffected.
- Workflow YAML parses cleanly.
- The deploy run triggered by merging this PR will confirm the warnings are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
