### PR TITLE
chore(ci): bump build Node from 20 (EOL) to 22 LTS

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
       - name: Install Node dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
Node 20 reached end-of-life in April 2026. Bump the `setup-node` build toolchain (`node-version`) from `20` to the `22` LTS line. Affects only the CI build environment for `npm ci` + `npm run build:css`; no site content change.

## Verification
- Workflow YAML parses cleanly.
- The deploy run triggered by this merge exercises the build on Node 22; a green run confirms the toolchain bump. (A failed build would simply not deploy, leaving the live site on the last good build.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
