### PR TITLE
Add project updates timeline to project layout

### DIFF
--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -30,6 +30,9 @@ layout: default
       {% if page.summary %}
       <p class="{% if page.hero_image %}mt-8{% else %}mt-4{% endif %} text-lg leading-relaxed text-aluminum-300">{{ page.summary }}</p>
       {% endif %}
+      {% if page.date_updated %}
+      <p class="mt-4 text-sm text-aluminum-400">Last updated: {{ page.date_updated | date: "%-d %b %Y" }}</p>
+      {% endif %}
       <dl class="mt-12 grid gap-6 rounded-2xl border border-aluminum-500/25 bg-graphite-700/60 p-6 text-sm text-aluminum-300 sm:grid-cols-2 lg:grid-cols-3">
         {% if page.role %}
         <div>
@@ -37,7 +40,12 @@ layout: default
           <dd class="mt-1 text-aluminum-100">{{ page.role }}</dd>
         </div>
         {% endif %}
-        {% if page.year %}
+        {% if page.date_published %}
+        <div>
+          <dt class="text-aluminum-400">Published</dt>
+          <dd class="mt-1 text-aluminum-100">{{ page.date_published | date: "%-d %b %Y" }}</dd>
+        </div>
+        {% elsif page.year %}
         <div>
           <dt class="text-aluminum-400">Year</dt>
           <dd class="mt-1 text-aluminum-100">{{ page.year }}</dd>
@@ -71,7 +79,7 @@ layout: default
     </div>
   </section>
 
-  {% if page.nav %}
+  {% if page.nav or page.updates %}
   <nav class="sticky top-0 z-40 border-b border-aluminum-500/25 bg-charcoal-900/95 backdrop-blur" aria-label="Page sections" data-sticky-nav>
     <div class="page-nav-bleed flex gap-3 overflow-x-auto py-4 text-sm" data-nav-scroll>
       {% for item in page.nav %}
@@ -81,6 +89,13 @@ layout: default
         >{{ item.label }}</a
       >
       {% endfor %}
+      {% if page.updates and page.updates.size > 0 %}
+      <a class="whitespace-nowrap rounded-full border border-transparent px-4 py-2 font-medium text-aluminum-300 transition hover:text-aluminum-100 hover:border-aluminum-500/40 aria-[current=page]:border-ember-400/50 aria-[current=page]:bg-ember-500/10 aria-[current=page]:text-ember-200 aria-[current=page]:texture-noise"
+        href="#updates"
+        data-nav-link
+        >Updates</a
+      >
+      {% endif %}
     </div>
   </nav>
   {% endif %}
@@ -90,6 +105,33 @@ layout: default
       {{ content }}
     </div>
   </div>
+  {% if page.updates and page.updates.size > 0 %}
+  <section id="updates" class="mx-auto max-w-5xl px-6 pb-16">
+    <h2 class="text-2xl font-semibold text-aluminum-100">Updates</h2>
+    <ol class="mt-8 space-y-10 border-l border-ember-400/30 pl-6 sm:pl-8">
+      {% assign sorted_updates = page.updates | sort: 'date' | reverse %}
+      {% for update in sorted_updates %}
+      <li id="{{ update.id }}" class="relative scroll-mt-24">
+        <span class="absolute -left-[7px] top-1.5 h-3 w-3 rounded-full border border-ember-400/60 bg-charcoal-900 sm:-left-[9px]" aria-hidden="true"></span>
+        {% if update.date %}
+        <p class="text-xs font-semibold uppercase tracking-[0.25em] text-aluminum-400">{{ update.date | date: "%-d %B %Y" }}</p>
+        {% endif %}
+        <h3 class="mt-2 text-xl font-semibold text-aluminum-100">
+          {% if update.id %}<a class="underline-offset-4 hover:text-ember-300 hover:underline" href="#{{ update.id }}">{{ update.title }}</a>{% else %}{{ update.title }}{% endif %}
+        </h3>
+        {% if update.summary %}
+        <p class="mt-3 leading-relaxed text-aluminum-300">{{ update.summary }}</p>
+        {% endif %}
+        {% if update.content %}
+        <div class="detail-content prose prose-invert mt-4 max-w-none">
+          {{ update.content | markdownify }}
+        </div>
+        {% endif %}
+      </li>
+      {% endfor %}
+    </ol>
+  </section>
+  {% endif %}
   {% if page.links %}
   <div class="mx-auto max-w-5xl px-6 pb-20">
     <div class="surface-panel p-6">


### PR DESCRIPTION
## What

Adds a reusable **updates timeline** to project case-study pages. No project page uses it yet — it's the layout capability only, available for future updates.

### `_layouts/project.html`
- Renders optional `date_published` / `date_updated` frontmatter (a "Last updated" line and a "Published" field, the latter superseding `year` when present).
- Adds an **Updates** link to the sticky section nav when a page has updates.
- Adds a date-sorted (newest-first) `#updates` timeline section, each entry rendering `date`, `title` (anchored by `id`), optional `summary`, and markdownified `content`.

## Notes
- The LifeOS WWDC 2026 update content originally bundled here was dropped (too much personal information, and unsubstantiated claims about the release). Only the reusable layout feature remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)