### PR TITLE
Add date tracking, sorting & tag filtering to projects showcase

### DIFF
--- a/_data/app_projects.yml
+++ b/_data/app_projects.yml
@@ -15,6 +15,9 @@
 - name: Career Pivot Navigator
   platform: Applied AI · Grounded MCP
   status: v0, open source
+  order: 1
+  date_started: "2026-05"
+  tags: [python, applied-ai, mcp, defence, open-source]
   icon: /assets/images/projects/career-pivot-navigator-icon.png
   icon_webp: /assets/images/projects/career-pivot-navigator-icon.webp
   link: /projects/career-pivot-navigator/
@@ -39,6 +42,9 @@
 - name: Open Defence Radar
   platform: Applied AI · Grounded RAG
   status: v1.0.0, open source
+  order: 2
+  date_started: "2026-04"
+  tags: [python, applied-ai, mcp, defence, open-source, rag]
   icon: /assets/images/projects/open-defence-radar-icon.png
   icon_webp: /assets/images/projects/open-defence-radar-icon.webp
   link: /projects/open-defence-radar/
@@ -64,6 +70,9 @@
 - name: PodForge
   platform: Personal Applied AI · Self-hosted
   status: Live, multi-feed
+  order: 3
+  date_started: "2026-03"
+  tags: [applied-ai, mcp, python, self-hosted, personal]
   icon: /assets/images/projects/podforge-icon.png
   icon_webp: /assets/images/projects/podforge-icon.webp
   link: /projects/podforge/
@@ -88,6 +97,9 @@
 - name: LifeOS
   platform: Personal Applied AI System
   status: Daily personal use
+  order: 4
+  date_started: "2026-02"
+  tags: [applied-ai, mcp, python, personal, obsidian]
   icon: /assets/images/projects/LifeOSAppIcon-256.png
   icon_webp: /assets/images/projects/LifeOSAppIcon-256.webp
   link: /projects/lifeos/
@@ -111,6 +123,9 @@
 - name: Peaking
   platform: iOS
   status: Active development
+  order: 5
+  date_started: "2024-06"
+  tags: [swift, ios, mapkit, cloudkit, personal]
   audience: For hikers and mountaineers who track summits, routes, and collection progress.
   icon: /assets/images/projects/PeakingAppIcon-256.png
   icon_webp: /assets/images/projects/PeakingAppIcon-256.webp
@@ -137,6 +152,9 @@
 - name: Training
   platform: iOS
   status: Active development
+  order: 6
+  date_started: "2025-01"
+  tags: [swift, ios, healthkit, personal]
   audience: For athletes, coaches, and habit-focused users who want stronger training consistency.
   icon: /assets/images/projects/TrainingAppIcon-256.png
   icon_webp: /assets/images/projects/TrainingAppIcon-256.webp
@@ -158,6 +176,9 @@
 
 - name: Squash Tracker
   platform: iOS & watchOS
+  order: 7
+  date_started: "2025-03"
+  tags: [swift, ios, watchos, healthkit, personal]
   audience: For squash players who want to record matches, track scores, and review performance over time.
   icon: /assets/images/projects/SquashTrackerAppIcon-256.png
   icon_webp: /assets/images/projects/SquashTrackerAppIcon-256.webp

--- a/_includes/projects-showcase.html
+++ b/_includes/projects-showcase.html
@@ -5,9 +5,60 @@
       <h2 class="text-3xl font-semibold text-aluminum-100">Projects</h2>
     </div>
     {% if app_projects != empty %}
-    <div class="mt-12 grid gap-6">
+
+    {%- comment -%}
+      Filter categories: display label mapped to the underlying tag slugs it matches.
+      A category pill only renders if at least one project carries one of its tags.
+    {%- endcomment -%}
+    {%- assign filter_categories = "Swift/iOS|swift,ios,watchos;Applied AI|applied-ai;MCP|mcp;Python|python;Defence|defence;Open Source|open-source;Personal|personal;Self-hosted|self-hosted" | split: ";" -%}
+    {%- assign all_tags = "" -%}
+    {%- for app in app_projects -%}
+      {%- if app.tags -%}{%- assign all_tags = all_tags | append: "," | append: app.tags | join: "," -%}{%- endif -%}
+    {%- endfor -%}
+
+    <div class="mt-10 space-y-6" data-projects-controls data-animate="section-heading">
+      <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4">
+        <span class="text-xs font-semibold uppercase tracking-[0.3em] text-aluminum-400">Sort</span>
+        <div class="flex flex-wrap gap-x-4 gap-y-2" data-projects-sort>
+          <button type="button" data-sort="featured" aria-pressed="true"
+            class="text-xs font-semibold uppercase tracking-[0.25em] text-ember-200 transition hover:text-ember-100">Featured</button>
+          <button type="button" data-sort="newest" aria-pressed="false"
+            class="text-xs font-semibold uppercase tracking-[0.25em] text-aluminum-400 transition hover:text-aluminum-200">Newest</button>
+          <button type="button" data-sort="oldest" aria-pressed="false"
+            class="text-xs font-semibold uppercase tracking-[0.25em] text-aluminum-400 transition hover:text-aluminum-200">Oldest</button>
+        </div>
+      </div>
+
+      <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:gap-4">
+        <span class="mt-1 text-xs font-semibold uppercase tracking-[0.3em] text-aluminum-400">Filter</span>
+        <div class="flex flex-wrap gap-2" data-projects-filter>
+          <button type="button" data-filter="all" aria-pressed="true"
+            class="rounded-full border border-ember-400/50 bg-ember-500/10 px-3 py-2 text-xs font-medium text-ember-200 transition">All</button>
+          {%- for category in filter_categories -%}
+            {%- assign parts = category | split: "|" -%}
+            {%- assign label = parts[0] -%}
+            {%- assign cat_tags = parts[1] | split: "," -%}
+            {%- assign has_match = false -%}
+            {%- for t in cat_tags -%}
+              {%- if all_tags contains t -%}{%- assign has_match = true -%}{%- endif -%}
+            {%- endfor -%}
+            {%- if has_match -%}
+            <button type="button" data-filter="{{ parts[1] }}" aria-pressed="false"
+              class="rounded-full border border-aluminum-500/30 px-3 py-2 text-xs font-medium text-aluminum-300 transition hover:border-aluminum-400/50 hover:text-aluminum-100">{{ label }}</button>
+            {%- endif -%}
+          {%- endfor -%}
+        </div>
+      </div>
+    </div>
+
+    <div class="mt-10 grid gap-6" data-projects-grid>
       {% for app in app_projects %}
-      <article class="surface-panel h-full p-6 lg:p-8" data-animate="project-card">
+      <article class="surface-panel h-full p-6 lg:p-8 transition-opacity duration-300 ease-in-out" data-animate="project-card"
+        data-project-card
+        data-tags="{{ app.tags | join: ',' }}"
+        data-started="{{ app.date_started }}"
+        data-finished="{{ app.date_finished }}"
+        data-order="{{ app.order }}">
 
         {% assign icon_size_class = 'h-32 w-32' %}
         {% assign icon_dim = '128' %}
@@ -31,6 +82,18 @@
           {% endif %}
           <div class="space-y-2">
             <p class="text-xs font-semibold uppercase tracking-[0.3em] text-aluminum-400">{{ app.platform }}{% if app.status %} · {{ app.status }}{% endif %}</p>
+            {% if app.date_started %}
+            {%- assign started_label = app.date_started | append: "-01" | date: "%b %Y" -%}
+            <p class="flex items-center gap-1.5 text-xs font-medium text-aluminum-400">
+              {% if app.date_finished and app.date_finished != "" %}
+              {%- assign finished_label = app.date_finished | append: "-01" | date: "%b %Y" -%}
+              <span>{{ started_label }} → {{ finished_label }}</span>
+              {% else %}
+              <span aria-hidden="true" class="inline-block h-1.5 w-1.5 rounded-full bg-ember-400"></span>
+              <span>{{ started_label }} → Present</span>
+              {% endif %}
+            </p>
+            {% endif %}
             <h3 class="text-xl font-semibold leading-tight text-aluminum-100">{{ app.name }}</h3>
             <p class="text-sm leading-relaxed text-aluminum-300">{{ app.audience }}</p>
           </div>
@@ -89,3 +152,137 @@
     {% endif %}
   </div>
 </section>
+
+<script>
+  (function () {
+    var grid = document.querySelector('[data-projects-grid]');
+    if (!grid) return;
+
+    var cards = Array.prototype.slice.call(grid.querySelectorAll('[data-project-card]'));
+    var sortRow = document.querySelector('[data-projects-sort]');
+    var filterRow = document.querySelector('[data-projects-filter]');
+
+    var activeSort = 'featured';
+    var activeFilters = []; // empty array == "All"
+
+    // ----- styling helpers -----
+    var SORT_ACTIVE = ['text-ember-200'];
+    var SORT_INACTIVE = ['text-aluminum-400'];
+
+    function styleSortButtons() {
+      sortRow.querySelectorAll('[data-sort]').forEach(function (btn) {
+        var isActive = btn.getAttribute('data-sort') === activeSort;
+        btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+        if (isActive) {
+          btn.classList.add('text-ember-200');
+          btn.classList.remove('text-aluminum-400');
+        } else {
+          btn.classList.add('text-aluminum-400');
+          btn.classList.remove('text-ember-200');
+        }
+      });
+    }
+
+    var PILL_ACTIVE = ['border-ember-400/50', 'bg-ember-500/10', 'text-ember-200'];
+    var PILL_INACTIVE = ['border-aluminum-500/30', 'text-aluminum-300'];
+
+    function setPillState(btn, isActive) {
+      btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+      if (isActive) {
+        btn.classList.add('border-ember-400/50', 'bg-ember-500/10', 'text-ember-200');
+        btn.classList.remove('border-aluminum-500/30', 'text-aluminum-300');
+      } else {
+        btn.classList.add('border-aluminum-500/30', 'text-aluminum-300');
+        btn.classList.remove('border-ember-400/50', 'bg-ember-500/10', 'text-ember-200');
+      }
+    }
+
+    function styleFilterButtons() {
+      filterRow.querySelectorAll('[data-filter]').forEach(function (btn) {
+        var key = btn.getAttribute('data-filter');
+        var isActive = key === 'all' ? activeFilters.length === 0 : activeFilters.indexOf(key) !== -1;
+        setPillState(btn, isActive);
+      });
+    }
+
+    // ----- sorting -----
+    function monthValue(started) {
+      // "2026-05" -> 202605, "" -> 0
+      if (!started) return 0;
+      var parts = started.split('-');
+      return parseInt(parts[0], 10) * 100 + parseInt(parts[1] || '0', 10);
+    }
+
+    function applySort() {
+      var sorted = cards.slice();
+      sorted.sort(function (a, b) {
+        if (activeSort === 'featured') {
+          return parseInt(a.getAttribute('data-order'), 10) - parseInt(b.getAttribute('data-order'), 10);
+        }
+        var aStart = monthValue(a.getAttribute('data-started'));
+        var bStart = monthValue(b.getAttribute('data-started'));
+        if (activeSort === 'newest') {
+          // ongoing (no finished date) first, then most recent start
+          var aOngoing = a.getAttribute('data-finished') ? 0 : 1;
+          var bOngoing = b.getAttribute('data-finished') ? 0 : 1;
+          if (aOngoing !== bOngoing) return bOngoing - aOngoing;
+          return bStart - aStart;
+        }
+        // oldest
+        return aStart - bStart;
+      });
+      sorted.forEach(function (card) { grid.appendChild(card); });
+    }
+
+    // ----- filtering -----
+    function applyFilter() {
+      cards.forEach(function (card) {
+        var cardTags = (card.getAttribute('data-tags') || '').split(',');
+        var show = activeFilters.length === 0;
+        if (!show) {
+          // OR logic: visible if the card has ANY tag in ANY active category
+          for (var i = 0; i < activeFilters.length && !show; i++) {
+            var catTags = activeFilters[i].split(',');
+            for (var j = 0; j < catTags.length; j++) {
+              if (cardTags.indexOf(catTags[j]) !== -1) { show = true; break; }
+            }
+          }
+        }
+        if (show) {
+          card.classList.remove('hidden', 'opacity-0');
+        } else {
+          card.classList.add('opacity-0');
+          card.classList.add('hidden');
+        }
+      });
+    }
+
+    // ----- events -----
+    sortRow.addEventListener('click', function (e) {
+      var btn = e.target.closest('[data-sort]');
+      if (!btn) return;
+      activeSort = btn.getAttribute('data-sort');
+      styleSortButtons();
+      applySort();
+    });
+
+    filterRow.addEventListener('click', function (e) {
+      var btn = e.target.closest('[data-filter]');
+      if (!btn) return;
+      var key = btn.getAttribute('data-filter');
+      if (key === 'all') {
+        activeFilters = [];
+      } else {
+        var idx = activeFilters.indexOf(key);
+        if (idx === -1) activeFilters.push(key);
+        else activeFilters.splice(idx, 1);
+      }
+      styleFilterButtons();
+      applyFilter();
+    });
+
+    styleSortButtons();
+    styleFilterButtons();
+    applySort();
+  })();
+</script>


### PR DESCRIPTION
## Summary

Adds date tracking, sorting, and tag-based filtering to the home-page projects showcase. Driven by `_data/app_projects.yml` and rendered by `_includes/projects-showcase.html`.

### Data (`_data/app_projects.yml`)
Every project now carries:
- `order:` — preserves the current array position as the **Featured** sort default
- `date_started:` — year-month (e.g. `"2026-05"`)
- `tags:` — lowercase tag slugs
- (`date_finished:` supported by the template; all current projects are ongoing so it's omitted)

### Include (`_includes/projects-showcase.html`)
- **Sort controls** — Featured (by `order`), Newest (`date_started` desc, ongoing first), Oldest (asc). Active sort gets the ember highlight.
- **Filter pills** — built from the union of project tags, grouped into display categories (Swift/iOS, Applied AI, MCP, Python, Defence, Open Source, Personal, Self-hosted). A category pill only renders if a project matches it. "All" is first and active by default; multiple filters use **OR** logic; active pills get the ember treatment.
- **Date line per card** — "Jun 2024 → Present" with a small ember dot for ongoing, "Mar 2026 → May 2026" for finished. Months as 3-letter abbreviations.
- **Interactivity** — vanilla JS embedded in the include. Each card exposes `data-tags` / `data-started` / `data-finished` / `data-order`. Sort reorders DOM nodes; filter toggles a `hidden`/`opacity-0` class (not DOM removal) with a 0.3s opacity transition.

Matches the existing charcoal/aluminum/ember design language and the sticky-nav pill style; controls sit between the heading and grid, and wrap/stack on mobile.

## Verification
- `JEKYLL_NO_BUNDLER_REQUIRE=1 jekyll build` succeeds with no Liquid errors; all 7 projects render.
- Verified in the browser preview: data attributes render correctly on every card; Featured/Newest/Oldest produce the correct orderings; Swift/iOS filter shows the 3 Swift apps; Swift+Defence (OR) shows 5; "All" resets to 7. Active-state ember styling and the 0.3s transition are wired and confirmed via computed styles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)