### PR TITLE
Projects showcase: sorting, tag filtering & per-project updates timeline

### DIFF
--- a/_data/app_projects.yml
+++ b/_data/app_projects.yml
@@ -15,6 +15,9 @@
 - name: Career Pivot Navigator
   platform: Applied AI · Grounded MCP
   status: v0, open source
+  order: 1
+  date_started: "2026-05"
+  tags: [python, applied-ai, mcp, defence, open-source]
   icon: /assets/images/projects/career-pivot-navigator-icon.png
   icon_webp: /assets/images/projects/career-pivot-navigator-icon.webp
   link: /projects/career-pivot-navigator/
@@ -39,6 +42,9 @@
 - name: Open Defence Radar
   platform: Applied AI · Grounded RAG
   status: v1.0.0, open source
+  order: 2
+  date_started: "2026-04"
+  tags: [python, applied-ai, mcp, defence, open-source, rag]
   icon: /assets/images/projects/open-defence-radar-icon.png
   icon_webp: /assets/images/projects/open-defence-radar-icon.webp
   link: /projects/open-defence-radar/
@@ -64,6 +70,9 @@
 - name: PodForge
   platform: Personal Applied AI · Self-hosted
   status: Live, multi-feed
+  order: 3
+  date_started: "2026-03"
+  tags: [applied-ai, mcp, python, self-hosted, personal]
   icon: /assets/images/projects/podforge-icon.png
   icon_webp: /assets/images/projects/podforge-icon.webp
   link: /projects/podforge/
@@ -88,6 +97,9 @@
 - name: LifeOS
   platform: Personal Applied AI System
   status: Daily personal use
+  order: 4
+  date_started: "2026-02"
+  tags: [applied-ai, mcp, python, personal, obsidian]
   icon: /assets/images/projects/LifeOSAppIcon-256.png
   icon_webp: /assets/images/projects/LifeOSAppIcon-256.webp
   link: /projects/lifeos/
@@ -111,6 +123,9 @@
 - name: Peaking
   platform: iOS
   status: Active development
+  order: 5
+  date_started: "2024-06"
+  tags: [swift, ios, mapkit, cloudkit, personal]
   audience: For hikers and mountaineers who track summits, routes, and collection progress.
   icon: /assets/images/projects/PeakingAppIcon-256.png
   icon_webp: /assets/images/projects/PeakingAppIcon-256.webp
@@ -137,6 +152,9 @@
 - name: Training
   platform: iOS
   status: Active development
+  order: 6
+  date_started: "2025-01"
+  tags: [swift, ios, healthkit, personal]
   audience: For athletes, coaches, and habit-focused users who want stronger training consistency.
   icon: /assets/images/projects/TrainingAppIcon-256.png
   icon_webp: /assets/images/projects/TrainingAppIcon-256.webp
@@ -158,6 +176,9 @@
 
 - name: Squash Tracker
   platform: iOS & watchOS
+  order: 7
+  date_started: "2025-03"
+  tags: [swift, ios, watchos, healthkit, personal]
   audience: For squash players who want to record matches, track scores, and review performance over time.
   icon: /assets/images/projects/SquashTrackerAppIcon-256.png
   icon_webp: /assets/images/projects/SquashTrackerAppIcon-256.webp

--- a/_includes/projects-showcase.html
+++ b/_includes/projects-showcase.html
@@ -5,9 +5,60 @@
       <h2 class="text-3xl font-semibold text-aluminum-100">Projects</h2>
     </div>
     {% if app_projects != empty %}
-    <div class="mt-12 grid gap-6">
+
+    {%- comment -%}
+      Filter categories: display label mapped to the underlying tag slugs it matches.
+      A category pill only renders if at least one project carries one of its tags.
+    {%- endcomment -%}
+    {%- assign filter_categories = "Swift/iOS|swift,ios,watchos;Applied AI|applied-ai;MCP|mcp;Python|python;Defence|defence;Open Source|open-source;Personal|personal;Self-hosted|self-hosted" | split: ";" -%}
+    {%- assign all_tags = "" -%}
+    {%- for app in app_projects -%}
+      {%- if app.tags -%}{%- assign all_tags = all_tags | append: "," | append: app.tags | join: "," -%}{%- endif -%}
+    {%- endfor -%}
+
+    <div class="mt-10 space-y-6" data-projects-controls data-animate="section-heading">
+      <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4">
+        <span class="text-xs font-semibold uppercase tracking-[0.3em] text-aluminum-400">Sort</span>
+        <div class="flex flex-wrap gap-x-4 gap-y-2" data-projects-sort>
+          <button type="button" data-sort="featured" aria-pressed="true"
+            class="text-xs font-semibold uppercase tracking-[0.25em] text-ember-200 transition hover:text-ember-100">Featured</button>
+          <button type="button" data-sort="newest" aria-pressed="false"
+            class="text-xs font-semibold uppercase tracking-[0.25em] text-aluminum-400 transition hover:text-aluminum-200">Newest</button>
+          <button type="button" data-sort="oldest" aria-pressed="false"
+            class="text-xs font-semibold uppercase tracking-[0.25em] text-aluminum-400 transition hover:text-aluminum-200">Oldest</button>
+        </div>
+      </div>
+
+      <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:gap-4">
+        <span class="mt-1 text-xs font-semibold uppercase tracking-[0.3em] text-aluminum-400">Filter</span>
+        <div class="flex flex-wrap gap-2" data-projects-filter>
+          <button type="button" data-filter="all" aria-pressed="true"
+            class="rounded-full border border-ember-400/50 bg-ember-500/10 px-3 py-2 text-xs font-medium text-ember-200 transition">All</button>
+          {%- for category in filter_categories -%}
+            {%- assign parts = category | split: "|" -%}
+            {%- assign label = parts[0] -%}
+            {%- assign cat_tags = parts[1] | split: "," -%}
+            {%- assign has_match = false -%}
+            {%- for t in cat_tags -%}
+              {%- if all_tags contains t -%}{%- assign has_match = true -%}{%- endif -%}
+            {%- endfor -%}
+            {%- if has_match -%}
+            <button type="button" data-filter="{{ parts[1] }}" aria-pressed="false"
+              class="rounded-full border border-aluminum-500/30 px-3 py-2 text-xs font-medium text-aluminum-300 transition hover:border-aluminum-400/50 hover:text-aluminum-100">{{ label }}</button>
+            {%- endif -%}
+          {%- endfor -%}
+        </div>
+      </div>
+    </div>
+
+    <div class="mt-10 grid gap-6" data-projects-grid>
       {% for app in app_projects %}
-      <article class="surface-panel h-full p-6 lg:p-8" data-animate="project-card">
+      <article class="surface-panel h-full p-6 lg:p-8 transition-opacity duration-300 ease-in-out" data-animate="project-card"
+        data-project-card
+        data-tags="{{ app.tags | join: ',' }}"
+        data-started="{{ app.date_started }}"
+        data-finished="{{ app.date_finished }}"
+        data-order="{{ app.order }}">
 
         {% assign icon_size_class = 'h-32 w-32' %}
         {% assign icon_dim = '128' %}
@@ -31,6 +82,18 @@
           {% endif %}
           <div class="space-y-2">
             <p class="text-xs font-semibold uppercase tracking-[0.3em] text-aluminum-400">{{ app.platform }}{% if app.status %} · {{ app.status }}{% endif %}</p>
+            {% if app.date_started %}
+            {%- assign started_label = app.date_started | append: "-01" | date: "%b %Y" -%}
+            <p class="flex items-center gap-1.5 text-xs font-medium text-aluminum-400">
+              {% if app.date_finished and app.date_finished != "" %}
+              {%- assign finished_label = app.date_finished | append: "-01" | date: "%b %Y" -%}
+              <span>{{ started_label }} → {{ finished_label }}</span>
+              {% else %}
+              <span aria-hidden="true" class="inline-block h-1.5 w-1.5 rounded-full bg-ember-400"></span>
+              <span>{{ started_label }} → Present</span>
+              {% endif %}
+            </p>
+            {% endif %}
             <h3 class="text-xl font-semibold leading-tight text-aluminum-100">{{ app.name }}</h3>
             <p class="text-sm leading-relaxed text-aluminum-300">{{ app.audience }}</p>
           </div>
@@ -89,3 +152,137 @@
     {% endif %}
   </div>
 </section>
+
+<script>
+  (function () {
+    var grid = document.querySelector('[data-projects-grid]');
+    if (!grid) return;
+
+    var cards = Array.prototype.slice.call(grid.querySelectorAll('[data-project-card]'));
+    var sortRow = document.querySelector('[data-projects-sort]');
+    var filterRow = document.querySelector('[data-projects-filter]');
+
+    var activeSort = 'featured';
+    var activeFilters = []; // empty array == "All"
+
+    // ----- styling helpers -----
+    var SORT_ACTIVE = ['text-ember-200'];
+    var SORT_INACTIVE = ['text-aluminum-400'];
+
+    function styleSortButtons() {
+      sortRow.querySelectorAll('[data-sort]').forEach(function (btn) {
+        var isActive = btn.getAttribute('data-sort') === activeSort;
+        btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+        if (isActive) {
+          btn.classList.add('text-ember-200');
+          btn.classList.remove('text-aluminum-400');
+        } else {
+          btn.classList.add('text-aluminum-400');
+          btn.classList.remove('text-ember-200');
+        }
+      });
+    }
+
+    var PILL_ACTIVE = ['border-ember-400/50', 'bg-ember-500/10', 'text-ember-200'];
+    var PILL_INACTIVE = ['border-aluminum-500/30', 'text-aluminum-300'];
+
+    function setPillState(btn, isActive) {
+      btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+      if (isActive) {
+        btn.classList.add('border-ember-400/50', 'bg-ember-500/10', 'text-ember-200');
+        btn.classList.remove('border-aluminum-500/30', 'text-aluminum-300');
+      } else {
+        btn.classList.add('border-aluminum-500/30', 'text-aluminum-300');
+        btn.classList.remove('border-ember-400/50', 'bg-ember-500/10', 'text-ember-200');
+      }
+    }
+
+    function styleFilterButtons() {
+      filterRow.querySelectorAll('[data-filter]').forEach(function (btn) {
+        var key = btn.getAttribute('data-filter');
+        var isActive = key === 'all' ? activeFilters.length === 0 : activeFilters.indexOf(key) !== -1;
+        setPillState(btn, isActive);
+      });
+    }
+
+    // ----- sorting -----
+    function monthValue(started) {
+      // "2026-05" -> 202605, "" -> 0
+      if (!started) return 0;
+      var parts = started.split('-');
+      return parseInt(parts[0], 10) * 100 + parseInt(parts[1] || '0', 10);
+    }
+
+    function applySort() {
+      var sorted = cards.slice();
+      sorted.sort(function (a, b) {
+        if (activeSort === 'featured') {
+          return parseInt(a.getAttribute('data-order'), 10) - parseInt(b.getAttribute('data-order'), 10);
+        }
+        var aStart = monthValue(a.getAttribute('data-started'));
+        var bStart = monthValue(b.getAttribute('data-started'));
+        if (activeSort === 'newest') {
+          // ongoing (no finished date) first, then most recent start
+          var aOngoing = a.getAttribute('data-finished') ? 0 : 1;
+          var bOngoing = b.getAttribute('data-finished') ? 0 : 1;
+          if (aOngoing !== bOngoing) return bOngoing - aOngoing;
+          return bStart - aStart;
+        }
+        // oldest
+        return aStart - bStart;
+      });
+      sorted.forEach(function (card) { grid.appendChild(card); });
+    }
+
+    // ----- filtering -----
+    function applyFilter() {
+      cards.forEach(function (card) {
+        var cardTags = (card.getAttribute('data-tags') || '').split(',');
+        var show = activeFilters.length === 0;
+        if (!show) {
+          // OR logic: visible if the card has ANY tag in ANY active category
+          for (var i = 0; i < activeFilters.length && !show; i++) {
+            var catTags = activeFilters[i].split(',');
+            for (var j = 0; j < catTags.length; j++) {
+              if (cardTags.indexOf(catTags[j]) !== -1) { show = true; break; }
+            }
+          }
+        }
+        if (show) {
+          card.classList.remove('hidden', 'opacity-0');
+        } else {
+          card.classList.add('opacity-0');
+          card.classList.add('hidden');
+        }
+      });
+    }
+
+    // ----- events -----
+    sortRow.addEventListener('click', function (e) {
+      var btn = e.target.closest('[data-sort]');
+      if (!btn) return;
+      activeSort = btn.getAttribute('data-sort');
+      styleSortButtons();
+      applySort();
+    });
+
+    filterRow.addEventListener('click', function (e) {
+      var btn = e.target.closest('[data-filter]');
+      if (!btn) return;
+      var key = btn.getAttribute('data-filter');
+      if (key === 'all') {
+        activeFilters = [];
+      } else {
+        var idx = activeFilters.indexOf(key);
+        if (idx === -1) activeFilters.push(key);
+        else activeFilters.splice(idx, 1);
+      }
+      styleFilterButtons();
+      applyFilter();
+    });
+
+    styleSortButtons();
+    styleFilterButtons();
+    applySort();
+  })();
+</script>

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -30,6 +30,9 @@ layout: default
       {% if page.summary %}
       <p class="{% if page.hero_image %}mt-8{% else %}mt-4{% endif %} text-lg leading-relaxed text-aluminum-300">{{ page.summary }}</p>
       {% endif %}
+      {% if page.date_updated %}
+      <p class="mt-4 text-sm text-aluminum-400">Last updated: {{ page.date_updated | date: "%-d %b %Y" }}</p>
+      {% endif %}
       <dl class="mt-12 grid gap-6 rounded-2xl border border-aluminum-500/25 bg-graphite-700/60 p-6 text-sm text-aluminum-300 sm:grid-cols-2 lg:grid-cols-3">
         {% if page.role %}
         <div>
@@ -37,7 +40,12 @@ layout: default
           <dd class="mt-1 text-aluminum-100">{{ page.role }}</dd>
         </div>
         {% endif %}
-        {% if page.year %}
+        {% if page.date_published %}
+        <div>
+          <dt class="text-aluminum-400">Published</dt>
+          <dd class="mt-1 text-aluminum-100">{{ page.date_published | date: "%-d %b %Y" }}</dd>
+        </div>
+        {% elsif page.year %}
         <div>
           <dt class="text-aluminum-400">Year</dt>
           <dd class="mt-1 text-aluminum-100">{{ page.year }}</dd>
@@ -71,7 +79,7 @@ layout: default
     </div>
   </section>
 
-  {% if page.nav %}
+  {% if page.nav or page.updates %}
   <nav class="sticky top-0 z-40 border-b border-aluminum-500/25 bg-charcoal-900/95 backdrop-blur" aria-label="Page sections" data-sticky-nav>
     <div class="page-nav-bleed flex gap-3 overflow-x-auto py-4 text-sm" data-nav-scroll>
       {% for item in page.nav %}
@@ -81,6 +89,13 @@ layout: default
         >{{ item.label }}</a
       >
       {% endfor %}
+      {% if page.updates and page.updates.size > 0 %}
+      <a class="whitespace-nowrap rounded-full border border-transparent px-4 py-2 font-medium text-aluminum-300 transition hover:text-aluminum-100 hover:border-aluminum-500/40 aria-[current=page]:border-ember-400/50 aria-[current=page]:bg-ember-500/10 aria-[current=page]:text-ember-200 aria-[current=page]:texture-noise"
+        href="#updates"
+        data-nav-link
+        >Updates</a
+      >
+      {% endif %}
     </div>
   </nav>
   {% endif %}
@@ -90,6 +105,33 @@ layout: default
       {{ content }}
     </div>
   </div>
+  {% if page.updates and page.updates.size > 0 %}
+  <section id="updates" class="mx-auto max-w-5xl px-6 pb-16">
+    <h2 class="text-2xl font-semibold text-aluminum-100">Updates</h2>
+    <ol class="mt-8 space-y-10 border-l border-ember-400/30 pl-6 sm:pl-8">
+      {% assign sorted_updates = page.updates | sort: 'date' | reverse %}
+      {% for update in sorted_updates %}
+      <li id="{{ update.id }}" class="relative scroll-mt-24">
+        <span class="absolute -left-[7px] top-1.5 h-3 w-3 rounded-full border border-ember-400/60 bg-charcoal-900 sm:-left-[9px]" aria-hidden="true"></span>
+        {% if update.date %}
+        <p class="text-xs font-semibold uppercase tracking-[0.25em] text-aluminum-400">{{ update.date | date: "%-d %B %Y" }}</p>
+        {% endif %}
+        <h3 class="mt-2 text-xl font-semibold text-aluminum-100">
+          {% if update.id %}<a class="underline-offset-4 hover:text-ember-300 hover:underline" href="#{{ update.id }}">{{ update.title }}</a>{% else %}{{ update.title }}{% endif %}
+        </h3>
+        {% if update.summary %}
+        <p class="mt-3 leading-relaxed text-aluminum-300">{{ update.summary }}</p>
+        {% endif %}
+        {% if update.content %}
+        <div class="detail-content prose prose-invert mt-4 max-w-none">
+          {{ update.content | markdownify }}
+        </div>
+        {% endif %}
+      </li>
+      {% endfor %}
+    </ol>
+  </section>
+  {% endif %}
   {% if page.links %}
   <div class="mx-auto max-w-5xl px-6 pb-20">
     <div class="surface-panel p-6">


### PR DESCRIPTION
## Summary

Combines two project-page features into one branch (supersedes #121 and #120):

1. **Home-page projects showcase** — date tracking, sorting, and tag-based filtering (was #121).
2. **Per-project updates timeline** — a data-driven "Updates" section on the project layout (was #120).

The WWDC update content originally drafted alongside the timeline has been scrapped; only the **template** ships here. It renders purely from per-page `updates:` front matter, so it stays hidden until real entries are added.

## Changes

**`_data/app_projects.yml`** — every project gains `order`, `date_started`, and `tags` (template also supports `date_finished`).

**`_includes/projects-showcase.html`**
- Sort controls: Featured (`order`) / Newest (`date_started` desc, ongoing first) / Oldest (asc); active gets the ember highlight.
- Filter pills built from the union of tags, grouped into display categories (Swift/iOS, Applied AI, MCP, Python, Defence, Open Source, Personal, Self-hosted); a category only renders if a project matches it. "All" first/active by default; multiple filters use OR logic; active pills get ember treatment.
- Per-card date line ("Jun 2024 → Present" with an ember dot for ongoing).
- Vanilla JS: cards expose `data-tags/started/finished/order`; sort reorders DOM nodes, filter toggles `hidden`/`opacity-0` with a 0.3s opacity transition.

**`_layouts/project.html`**
- New "Updates" timeline section, an "Updates" sticky-nav link, and `date_published` / `date_updated` metadata, all conditional on front matter. Updates sort newest-first, support per-entry anchors, and render markdown content.

## Verification (local, system Jekyll, no bundler)
- `jekyll build` clean, no Liquid errors; all 7 projects render.
- Home: 9 filter pills + 3 sort controls; Featured/Newest/Oldest orderings correct; Swift/iOS → 3, Swift+Defence (OR) → 5, "All" → 7.
- Project page: updates template verified with a throwaway entry (section, nav link, formatted date, markdown all render), then reverted; with no `updates:` data the section is correctly absent and existing pages are unaffected.

Closes #121
Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)