### PR TITLE
Fix: reveal project cards moved into view by sort/filter

### DIFF
--- a/_includes/projects-showcase.html
+++ b/_includes/projects-showcase.html
@@ -205,6 +205,24 @@
       });
     }
 
+    // Reveal animations are driven by GSAP ScrollTrigger (gsap-animations.js),
+    // which caches each card's pixel position at init. Reordering or hiding cards
+    // moves them without ScrollTrigger knowing, so a card that scrolls into view
+    // after a sort/filter would stay at its initial opacity:0 and never reveal.
+    // Recompute positions (and fire any pending onEnter) after we mutate the DOM.
+    // Guarded: ScrollTrigger loads via defer, so it is absent during the initial
+    // parse-time applySort() — that order is set before GSAP initialises anyway.
+    // Called synchronously after the DOM mutation: the reorder (appendChild) and
+    // visibility toggles are already applied, and ScrollTrigger.refresh() forces
+    // its own layout re-measure, so there is no need to wait a frame — and waiting
+    // on requestAnimationFrame would be unreliable if the tab is not painting.
+    function refreshReveal() {
+      var ST = window.ScrollTrigger;
+      if (ST && typeof ST.refresh === 'function') {
+        ST.refresh();
+      }
+    }
+
     // ----- sorting -----
     function monthValue(started) {
       // "2026-05" -> 202605, "" -> 0
@@ -232,6 +250,7 @@
         return aStart - bStart;
       });
       sorted.forEach(function (card) { grid.appendChild(card); });
+      refreshReveal();
     }
 
     // ----- filtering -----
@@ -255,6 +274,7 @@
           card.classList.add('hidden');
         }
       });
+      refreshReveal();
     }
 
     // ----- events -----


### PR DESCRIPTION
## Summary

Follow-up to #122. The reveal animation fix was pushed to the showcase branch *after* #122 was squash-merged, so it didn't land on `main`. This PR integrates just that fix.

## The bug
Project-card on-appear animations are driven by GSAP ScrollTrigger, which caches each card's document position at init. Sorting reorders the DOM nodes (and filtering hides them) without ScrollTrigger knowing, so a card that was below the fold (`opacity: 0`, never triggered) would move into view still believing it lived further down the page — its `onEnter` never fired and it stayed invisible.

## The fix
Call `ScrollTrigger.refresh()` synchronously after each sort/filter DOM mutation so positions are re-measured and reveals fire for cards now in view. Synchronous rather than `requestAnimationFrame`-deferred because `refresh()` forces its own layout read and a non-painting tab can starve rAF.

## Verification
Verified deterministically via each trigger's measured `start` position (the headless preview is 0×0 and can't paint reveals): reordering without refresh leaves a top card with its stale bottom-of-page position (the bug); after `refresh()` positions track the new DOM order. The real "Oldest" sort click reproduces this through the UI, and there are no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)