### PR TITLE
fix(ci): use npm install in Astro deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,10 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v6
       - name: Install dependencies
-        run: npm ci
+        # npm install (not ci) so the runner resolves platform-specific optional
+        # deps (Tailwind v4's native engine) regardless of which platform/npm
+        # version generated the committed lockfile.
+        run: npm install --no-audit --no-fund
       - name: Build with Astro
         run: npm run build
       - name: Upload artifact


### PR DESCRIPTION
Fixes the failed deploy from #125: GitHub's runner couldn't `npm ci` because the macOS/npm-11 lockfile resolves Tailwind v4's native optional deps differently than Linux/npm-10. Switches the install step to `npm install` so the runner resolves platform deps itself. No app changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)