### PR TITLE
fix(a11y): WCAG AA colour contrast across light and dark mode

### DIFF
--- a/src/components/diagrams/career-pivot-navigator-architecture.svg
+++ b/src/components/diagrams/career-pivot-navigator-architecture.svg
@@ -9,7 +9,7 @@
         --d-card-border: rgb(var(--aluminum-500, 90 94 101) / 0.4);
         --d-text: rgb(var(--aluminum-100, 228 231 236));
         --d-mid: rgb(var(--aluminum-300, 157 161 169));
-        --d-muted: rgb(var(--aluminum-400, 131 135 143));
+        --d-muted: rgb(var(--aluminum-300, 157 161 169));
         --d-accent: rgb(var(--ember-400, 240 139 74));
         --d-on-accent: rgb(var(--charcoal-950, 7 8 10));
         --d-soft: rgb(var(--aluminum-400, 131 135 143));

--- a/src/components/diagrams/career-pivot-navigator-plan.svg
+++ b/src/components/diagrams/career-pivot-navigator-plan.svg
@@ -10,11 +10,14 @@
         --d-card-border: rgb(var(--aluminum-500, 90 94 101) / 0.4);
         --d-text: rgb(var(--aluminum-100, 228 231 236));
         --d-mid: rgb(var(--aluminum-300, 157 161 169));
-        --d-muted: rgb(var(--aluminum-400, 131 135 143));
+        --d-muted: rgb(var(--aluminum-300, 157 161 169));
         --d-accent: rgb(var(--ember-400, 240 139 74));
         --d-on-accent: rgb(var(--charcoal-950, 7 8 10));
         display:block; width:100%; height:auto;
       }
+      /* Accent-coloured TEXT (ember-400) is ~2:1 on the light card/page; darken it
+         to ember-200 in light mode only (the vivid dark-theme accent is untouched). */
+      :root[data-theme="light"] .cpn-plan .pilltext{ fill: rgb(var(--ember-200, 160 68 0)); }
       .cpn-plan text{ font-family:"Styrene B","Inter",-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; }
       .cpn-plan .h1{ font-size:23px; font-weight:600; fill:var(--d-text); }
       .cpn-plan .sub{ font-size:14px; fill:var(--d-mid); }

--- a/src/components/diagrams/open-defence-radar-architecture.svg
+++ b/src/components/diagrams/open-defence-radar-architecture.svg
@@ -9,7 +9,7 @@
         --d-card-border: rgb(var(--aluminum-500, 90 94 101) / 0.4);
         --d-text: rgb(var(--aluminum-100, 228 231 236));
         --d-mid: rgb(var(--aluminum-300, 157 161 169));
-        --d-muted: rgb(var(--aluminum-400, 131 135 143));
+        --d-muted: rgb(var(--aluminum-300, 157 161 169));
         --d-accent: rgb(var(--ember-400, 240 139 74));
         --d-on-accent: rgb(var(--charcoal-950, 7 8 10));
         --d-soft: rgb(var(--aluminum-400, 131 135 143));

--- a/src/components/diagrams/podforge-architecture.svg
+++ b/src/components/diagrams/podforge-architecture.svg
@@ -9,7 +9,7 @@
         --d-card-border: rgb(var(--aluminum-500, 90 94 101) / 0.4);
         --d-text: rgb(var(--aluminum-100, 228 231 236));
         --d-mid: rgb(var(--aluminum-300, 157 161 169));
-        --d-muted: rgb(var(--aluminum-400, 131 135 143));
+        --d-muted: rgb(var(--aluminum-300, 157 161 169));
         --d-accent: rgb(var(--ember-400, 240 139 74));
         --d-on-accent: rgb(var(--charcoal-950, 7 8 10));
         --d-soft: rgb(var(--aluminum-400, 131 135 143));

--- a/src/components/diagrams/podforge-output.svg
+++ b/src/components/diagrams/podforge-output.svg
@@ -10,12 +10,15 @@
         --d-card-border: rgb(var(--aluminum-500, 90 94 101) / 0.4);
         --d-text: rgb(var(--aluminum-100, 228 231 236));
         --d-mid: rgb(var(--aluminum-300, 157 161 169));
-        --d-muted: rgb(var(--aluminum-400, 131 135 143));
+        --d-muted: rgb(var(--aluminum-300, 157 161 169));
         --d-accent: rgb(var(--ember-400, 240 139 74));
         --d-accent-soft: rgb(var(--ember-400, 240 139 74) / 0.32);
         --d-on-accent: rgb(var(--charcoal-950, 7 8 10));
         display:block; width:100%; height:auto;
       }
+      /* Accent-coloured TEXT (ember-400) is ~2:1 on the light card/page; darken it
+         to ember-200 in light mode only (the vivid dark-theme accent is untouched). */
+      :root[data-theme="light"] .pf-out :is(.pill-t, .cue-lbl, .tc-now){ fill: rgb(var(--ember-200, 160 68 0)); }
       .pf-out text{ font-family:"Styrene B","Inter",-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; }
       .pf-out .mono{ font-family:"JetBrains Mono","SF Mono",Menlo,Consolas,monospace; }
       .pf-out .panel{ fill:var(--d-bg); stroke:var(--d-card-border); stroke-width:1; }

--- a/src/components/ui/ProjectsShowcase.tsx
+++ b/src/components/ui/ProjectsShowcase.tsx
@@ -110,7 +110,7 @@ export function ProjectsShowcase({ projects }: ProjectsShowcaseProps) {
                   aria-pressed={sort === s}
                   onClick={() => setSort(s)}
                   className={`text-xs font-semibold uppercase tracking-[0.25em] transition ${
-                    sort === s ? 'text-ember-200 hover:text-ember-100' : 'text-aluminum-400 hover:text-aluminum-200'
+                    sort === s ? 'text-ember-200 underline underline-offset-4' : 'text-aluminum-400 hover:text-aluminum-200'
                   }`}>
                   {s.charAt(0).toUpperCase() + s.slice(1)}
                 </button>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -87,7 +87,7 @@ const currentYear = new Date().getFullYear();
   </head>
   <body class="flex min-h-screen flex-col bg-charcoal-900 text-aluminum-100 antialiased">
     <a
-      class="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:rounded-md focus:bg-aluminum-100 focus:px-4 focus:py-2 focus:text-charcoal-950"
+      class="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:rounded-md focus:bg-aluminum-100 focus:px-4 focus:py-2 focus:text-charcoal-900"
       href="#main">Skip to content</a
     >
     <main id="main" class="flex-1">
@@ -101,23 +101,23 @@ const currentYear = new Date().getFullYear();
           <span aria-hidden="true">·</span>
           <p>
             Built with
-            <a href="https://astro.build/" class="transition hover:text-ember-300">Astro</a>,
-            <a href="https://react.dev/" class="transition hover:text-ember-300">React</a>,
-            <a href="https://tailwindcss.com/" class="transition hover:text-ember-300">Tailwind CSS</a>,
+            <a href="https://astro.build/" class="underline underline-offset-4 transition hover:text-ember-300 hover:underline">Astro</a>,
+            <a href="https://react.dev/" class="underline underline-offset-4 transition hover:text-ember-300 hover:underline">React</a>,
+            <a href="https://tailwindcss.com/" class="underline underline-offset-4 transition hover:text-ember-300 hover:underline">Tailwind CSS</a>,
             and
-            <a href="https://gsap.com/" class="transition hover:text-ember-300">GSAP</a>.
+            <a href="https://gsap.com/" class="underline underline-offset-4 transition hover:text-ember-300 hover:underline">GSAP</a>.
           </p>
         </div>
         <div class="flex flex-wrap items-center gap-4">
-          <a class="transition hover:text-ember-300" href={`mailto:${site.social.email}`}>{site.social.email}</a>
+          <a class="underline underline-offset-4 transition hover:text-ember-300 hover:underline" href={`mailto:${site.social.email}`}>{site.social.email}</a>
           {site.social.linkedin && (
-            <a class="transition hover:text-ember-300" href={site.social.linkedin}>LinkedIn</a>
+            <a class="underline underline-offset-4 transition hover:text-ember-300 hover:underline" href={site.social.linkedin}>LinkedIn</a>
           )}
           {site.social.github && (
-            <a class="transition hover:text-ember-300" href={site.social.github}>GitHub</a>
+            <a class="underline underline-offset-4 transition hover:text-ember-300 hover:underline" href={site.social.github}>GitHub</a>
           )}
           {site.social.medium && (
-            <a class="transition hover:text-ember-300" href={site.social.medium}>Medium</a>
+            <a class="underline underline-offset-4 transition hover:text-ember-300 hover:underline" href={site.social.medium}>Medium</a>
           )}
           <span aria-hidden="true">·</span>
           <div

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -31,7 +31,7 @@ function fmtFull(d?: Date | string): string {
       </div>
       <div class="mt-10">
         <a
-          class="text-sm text-aluminum-300 underline-offset-4 transition hover:text-ember-300 hover:underline"
+          class="text-sm text-aluminum-300 underline underline-offset-4 transition hover:text-ember-300 hover:underline"
           href="/">← Back to portfolio</a
         >
       </div>

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -28,7 +28,7 @@ const hasUpdates = (data.updates?.length ?? 0) > 0;
     <section class="border-b border-aluminum-500/25 bg-charcoal-900">
       <div class="mx-auto max-w-5xl px-6 py-20">
         <a
-          class="text-sm text-aluminum-300 underline-offset-4 transition hover:text-ember-300 hover:underline"
+          class="text-sm text-aluminum-300 underline underline-offset-4 transition hover:text-ember-300 hover:underline"
           href="/#projects">← Back to Projects</a
         >
         {
@@ -113,7 +113,7 @@ const hasUpdates = (data.updates?.length ?? 0) > 0;
             <ul class="mt-4 space-y-2 text-sm text-aluminum-300">
               {data.links.map((link) => (
                 <li>
-                  <a class="underline-offset-4 hover:text-ember-300 hover:underline" href={link.url}>
+                  <a class="underline underline-offset-4 hover:text-ember-300 hover:underline" href={link.url}>
                     {link.title}
                   </a>
                 </li>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -166,29 +166,11 @@
     box-shadow: 0 20px 45px -30px rgba(0, 0, 0, 0.08) !important;
   }
 
-  /* Light-mode CTA hover — ember-300 is darkened for link text, too dark as button bg */
-  :root[data-theme="light"] a.texture-noise:hover {
-    background-color: rgb(var(--ember-500));
-  }
-
-  /* Prose-invert overrides for light mode — adapts post/project pages automatically */
-  :root[data-theme="light"] .prose-invert {
-    --tw-prose-body: rgb(var(--aluminum-300));
-    --tw-prose-headings: rgb(var(--aluminum-100));
-    --tw-prose-links: rgb(var(--ember-300));
-    --tw-prose-bold: rgb(var(--aluminum-100));
-    --tw-prose-counters: rgb(var(--aluminum-400));
-    --tw-prose-bullets: rgb(var(--ember-300));
-    --tw-prose-hr: rgb(var(--aluminum-500) / 0.25);
-    --tw-prose-quotes: rgb(var(--aluminum-200));
-    --tw-prose-quote-borders: rgb(var(--ember-400) / 0.4);
-    --tw-prose-captions: rgb(var(--aluminum-400));
-    --tw-prose-code: rgb(var(--aluminum-200));
-    --tw-prose-pre-code: rgb(var(--aluminum-300));
-    --tw-prose-pre-bg: rgb(var(--graphite-700));
-    --tw-prose-th-borders: rgb(var(--aluminum-500) / 0.3);
-    --tw-prose-td-borders: rgb(var(--aluminum-500) / 0.2);
-  }
+  /* NOTE: the light-mode prose-invert and CTA-hover overrides live UNLAYERED
+     below this @layer block — see "Light-mode cascade-layer overrides". They
+     must beat @tailwindcss/typography and the hover:bg-* utilities, which
+     compile into the `utilities` layer (last in the cascade), so a rule inside
+     @layer components can never win regardless of specificity. */
 
   /* Consistent gutter between app icon and heading column across all project cards. */
   #projects .project-card__header { gap: 1.5rem; }
@@ -238,7 +220,9 @@
     --diagram-sensitive-bg: rgb(var(--graphite-700));
     --diagram-text-strong: rgb(var(--aluminum-100));
     --diagram-text-mid: rgb(var(--aluminum-300));
-    --diagram-text-muted: rgb(var(--aluminum-400));
+    /* aluminum-400 muted text falls to 4.0:1 on the graphite-600 spine cards;
+       aluminum-300 clears AA (5.6–6.6:1) for the small spine/lane sublabels. */
+    --diagram-text-muted: rgb(var(--aluminum-300));
     --diagram-accent: rgb(var(--ember-400));
     --diagram-on-accent: rgb(var(--charcoal-950));
     --diagram-edge-soft: rgb(var(--aluminum-400));
@@ -369,6 +353,48 @@
   @media (min-width: 640px) {
     .update-timeline__marker { margin-left: -2.25rem; }
   }
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+   Light-mode cascade-layer overrides (UNLAYERED — intentional).
+
+   @tailwindcss/typography (.prose / .prose-invert) and Tailwind's hover:bg-*
+   utilities compile into the `utilities` layer, which is LAST in the layer
+   order (theme, base, components, utilities). A layered rule — even one with
+   higher specificity — can never beat a later layer. These overrides therefore
+   sit outside any @layer so they win, since unlayered normal declarations
+   outrank every layered one. (Previously these lived in @layer components and
+   silently lost, leaving light-mode prose as the plugin's dark-on-dark invert
+   greys — ~1.4:1 body text on the near-white background.)
+   ────────────────────────────────────────────────────────────────────────── */
+
+/* Project / post case-study body copy in light mode. Drives the typography
+   plugin's prose variables from our runtime tokens; every pairing clears
+   WCAG 2.1 AA (body 7.9:1, headings 16:1, links 5:1) against charcoal-900. */
+:root[data-theme="light"] .prose-invert {
+  --tw-prose-body: rgb(var(--aluminum-300));
+  --tw-prose-headings: rgb(var(--aluminum-100));
+  --tw-prose-links: rgb(var(--ember-300));
+  --tw-prose-bold: rgb(var(--aluminum-100));
+  --tw-prose-counters: rgb(var(--aluminum-400));
+  --tw-prose-bullets: rgb(var(--ember-300));
+  --tw-prose-hr: rgb(var(--aluminum-500) / 0.25);
+  --tw-prose-quotes: rgb(var(--aluminum-200));
+  --tw-prose-quote-borders: rgb(var(--ember-400) / 0.4);
+  --tw-prose-captions: rgb(var(--aluminum-400));
+  --tw-prose-code: rgb(var(--aluminum-200));
+  --tw-prose-pre-code: rgb(var(--aluminum-300));
+  --tw-prose-pre-bg: rgb(var(--graphite-700));
+  --tw-prose-th-borders: rgb(var(--aluminum-500) / 0.3);
+  --tw-prose-td-borders: rgb(var(--aluminum-500) / 0.2);
+}
+
+/* Primary CTA hover in light mode. The hover:bg-ember-300 utility yields a
+   near-black label on a dark-orange fill (3.8:1). Land on ember-500 instead
+   (6.2:1). Scoped to .text-charcoal-950 (the solid-fill CTAs) so the ember-text
+   pill keeps its translucent ember-500/20 hover rather than a solid fill. */
+:root[data-theme="light"] a.texture-noise.text-charcoal-950:hover {
+  background-color: rgb(var(--ember-500));
 }
 
 @layer utilities {


### PR DESCRIPTION
Colour-based accessibility review across all elements in light and dark mode.

## Root cause
`@tailwindcss/typography` (`.prose`/`.prose-invert`) and Tailwind's `hover:`/`aria-` utilities compile into the **`utilities`** cascade layer (last/strongest in `theme, base, components, utilities`). The site's light-mode overrides lived in `@layer components`, so they silently lost — light-mode case-study/post body text rendered as the plugin's dark-on-dark invert greys (~1.4:1 on the near-white background), headings white-on-white. Fix: move those overrides **unlayered**.

## Fixed — WCAG 1.4.3 contrast (text)
| Element | Mode | Before | After |
|---|---|---|---|
| Case-study / post body text | light | 1.4:1 | 7.9:1 |
| Prose headings (white-on-white) | light | 1.05:1 | 16:1 |
| Bold / inline code / table headers | light | ~1.1:1 | 13–16:1 |
| Primary CTA hover (charcoal-950 on ember-300) | light | 3.80:1 | 6.2:1 |
| Diagram muted labels (`--d-muted`, 6 diagrams) | both | 4.0:1 | 5.6–6.6:1 |
| Skip-to-content link on focus (black-on-black) | light | 1.19:1 | 16:1 |
| Diagram accent text (ember-400) | light | ~2.0:1 | 5–6:1 |

## Fixed — WCAG 1.4.1 use of colour
Resting underlines added to footer links, "Back to Projects/portfolio", "Further reading", and the active Projects "Sort" option (previously distinguished by colour alone, <3:1 vs surrounding text).

## Deliberately not changed (verified 1.4.11-exempt)
Low-contrast divider/card borders, the active nav/filter pill border (state also carried by text colour + tint + ARIA), `aria-hidden` timeline rail/markers and "Present" dot, prose bullets, and diagram accent dots/lines — each is decorative or has redundant text/ARIA cues.

## Verification
- DOM-walk auditor (rendered colour vs composited background, handles oklch/alpha) across home, 4 case studies, post, peaking, privacy, style-guide, 404 — **0 text-contrast failures in both themes**.
- Every ratio re-computed with a deterministic sRGB engine.
- Dark mode confirmed unchanged; production `astro build` passes (15 pages); no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)