### PR TITLE
chore: skip Pages deploy for non-content changes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,10 @@ name: Deploy Astro site to GitHub Pages
 on:
   push:
     branches: ["main"]
+    paths-ignore:
+      - 'README.md'
+      - '.claude/**'
+      - 'docs/**'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Part of a cross-repo CI budget control pass (Liam is at ~90% of monthly GitHub Actions minutes).

## Change
`deploy.yml`: add `paths-ignore` for `README.md`, `.claude/**`, `docs/**` so documentation-only pushes to `main` skip the Astro build + Pages deploy.

ubuntu-latest (1x multiplier) — small saving, but avoids needless deploys.

## Trigger note
`deploy.yml` only runs on push to `main`, so opening this PR triggers no Actions run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)