### PR TITLE
Local Actions-free deploy + serve Pages from gh-pages branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,26 +1,29 @@
-name: Deploy Astro site to GitHub Pages
+name: Deploy site to gh-pages (manual)
 
+# MANUAL-ONLY on purpose. The site is served by GitHub Pages from the `gh-pages`
+# branch (Settings → Pages → "Deploy from a branch": gh-pages /), which uses
+# GitHub's free built-in Pages builder and spends ZERO Actions minutes. A normal
+# push to main therefore costs nothing and does not deploy.
+#
+# This workflow is the optional CLOUD equivalent of `scripts/deploy.sh`: run it
+# from the Actions tab (or `gh workflow run "Deploy site to gh-pages (manual)"`)
+# when you want a build on GitHub's runner instead of your laptop AND you are
+# under the Actions budget. It produces the exact same gh-pages output as the
+# local script. When the budget is exhausted, use `scripts/deploy.sh` locally
+# instead — see ~/GitHub/LOCAL-FALLBACK.md.
 on:
-  push:
-    branches: ["main"]
-    paths-ignore:
-      - 'README.md'
-      - '.claude/**'
-      - 'docs/**'
   workflow_dispatch:
 
+# Needs write access to push the built site to the gh-pages branch.
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
-# Allow one concurrent deployment; don't cancel an in-progress production deploy.
 concurrency:
-  group: "pages"
+  group: "pages-deploy"
   cancel-in-progress: false
 
 jobs:
-  build:
+  build-and-publish:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -30,8 +33,6 @@ jobs:
         with:
           node-version: "22"
           cache: "npm"
-      - name: Setup Pages
-        uses: actions/configure-pages@v6
       - name: Install dependencies
         # npm install (not ci) so the runner resolves platform-specific optional
         # deps (Tailwind v4's native engine) regardless of which platform/npm
@@ -39,18 +40,19 @@ jobs:
         run: npm install --no-audit --no-fund
       - name: Build with Astro
         run: npm run build
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
-        with:
-          path: ./dist
-
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5
+      - name: Add Pages serving files
+        run: |
+          echo "www.liamday.co.uk" > dist/CNAME
+          touch dist/.nojekyll
+      - name: Publish ./dist to gh-pages
+        run: |
+          cd dist
+          git init -q
+          git checkout -q -b gh-pages
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -q -m "Deploy ${{ github.sha }} (manual workflow_dispatch)"
+          git push -q -f \
+            "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" \
+            gh-pages

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# deploy.sh — build and publish liamday-site to GitHub Pages WITHOUT GitHub
+# Actions. This is the local fallback so the site can always ship — even when
+# the GitHub Actions minute budget is exhausted (see ~/GitHub/LOCAL-FALLBACK.md).
+#
+# How it works:
+#   1. npm install + `astro build`            -> ./dist
+#   2. guarantee dist/CNAME (custom domain) and dist/.nojekyll exist
+#   3. force-publish ./dist to the `gh-pages` branch as a single fresh commit
+#   4. push gh-pages — GitHub Pages (Settings -> Pages -> "Deploy from a branch":
+#      gh-pages /) serves it via the FREE built-in Pages builder, which does NOT
+#      consume the Actions minute quota. Zero Actions minutes per deploy.
+#
+# The committed deploy.yml does the exact same thing on `workflow_dispatch`, so a
+# cloud build is still available on demand when you are under budget.
+#
+# Usage:
+#   scripts/deploy.sh                build, then publish
+#   scripts/deploy.sh --skip-build   publish an already-built ./dist
+#
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+BRANCH="gh-pages"
+DOMAIN="www.liamday.co.uk"
+SKIP_BUILD=false
+[ "${1:-}" = "--skip-build" ] && SKIP_BUILD=true
+
+if ! $SKIP_BUILD; then
+  echo "==> npm install"
+  npm install --no-audit --no-fund
+  echo "==> astro build"
+  npm run build
+fi
+[ -d dist ] || { echo "deploy: ./dist not found — run without --skip-build" >&2; exit 1; }
+
+# GitHub Pages serving files (idempotent; public/ already provides both, this is
+# belt-and-braces in case of a --skip-build on a stale dist).
+echo "$DOMAIN" > dist/CNAME
+: > dist/.nojekyll
+
+REMOTE="$(git remote get-url origin)"
+SRC_SHA="$(git rev-parse --short HEAD)"
+STAMP="$(date -u '+%Y-%m-%d %H:%M:%SZ')"
+
+echo "==> Publishing ./dist to '$BRANCH' (single force-pushed commit)"
+(
+  cd dist
+  rm -rf .git
+  git init -q
+  git checkout -q -b "$BRANCH"
+  git add -A
+  git -c user.name='liamday-deploy' -c user.email='deploy@liamday.co.uk' \
+      commit -q -m "Deploy $STAMP (source $SRC_SHA)"
+  git push -q -f "$REMOTE" "$BRANCH"
+  rm -rf .git
+)
+
+echo "==> Done. Pushed '$BRANCH'."
+echo "    Live at https://$DOMAIN/ — served by the free Pages builder, 0 Actions minutes."


### PR DESCRIPTION
## What

Makes liamday-site deployable with **zero GitHub Actions minutes**, so an exhausted Actions budget no longer blocks shipping the site.

GitHub Pages is now configured (already applied) to serve from the `gh-pages` branch (`build_type: legacy` — GitHub's free built-in Pages builder), matching the GeoFidelity-site model. The built `dist/` is published to `gh-pages` either locally or via an on-demand cloud build.

## Changes

- **`scripts/deploy.sh`** — builds Astro and force-publishes `./dist` to `gh-pages` (writes `CNAME` + `.nojekyll`). The always-available local deploy path: `./scripts/deploy.sh`.
- **`public/.nojekyll`** — required so branch-based Pages serves Astro's underscore-prefixed `_astro/` assets (Jekyll would otherwise strip them).
- **`.github/workflows/deploy.yml`** — rewritten to `workflow_dispatch`-only, building + pushing to `gh-pages`. An optional cloud build that never auto-spends. Removing the `push:` trigger is what makes merging this PR cost **0 Actions minutes**.

## Verification

- `gh-pages` branch built + pushed locally.
- Pages source flipped to `gh-pages` via the API.
- `https://www.liamday.co.uk/` → `HTTP 200`; `/_astro/*.js` → `HTTP 200` (confirms `.nojekyll` works).

Part of the cross-repo local-fallback work — see `~/GitHub/LOCAL-FALLBACK.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)