### PR TITLE
Add animated stars background and refine card/hover UI

### DIFF
--- a/src/components/ui/ContactSection.tsx
+++ b/src/components/ui/ContactSection.tsx
@@ -9,7 +9,7 @@ export function ContactSection({ email, linkedin, github }: ContactSectionProps)
   return (
     <section
       id="contact"
-      className="scroll-mt-32 flex min-h-screen flex-col justify-center border-t border-aluminum-500/20 bg-charcoal-900">
+      className="scroll-mt-32 flex min-h-screen flex-col justify-center border-t border-aluminum-500/20 bg-transparent">
       <div className="relative mx-auto w-full max-w-3xl px-6 py-20 text-center" data-animate="contact-wrapper">
         <div
           aria-hidden="true"

--- a/src/components/ui/Hero.tsx
+++ b/src/components/ui/Hero.tsx
@@ -28,7 +28,7 @@ export function Hero({
   return (
     <section
       id="profile"
-      className="relative flex min-h-screen flex-col justify-center overflow-hidden border-b border-aluminum-500/20 bg-charcoal-900">
+      className="relative flex min-h-screen flex-col justify-center overflow-hidden border-b border-aluminum-500/20 bg-transparent">
       <div className="mx-auto flex w-full max-w-5xl flex-col justify-center gap-10 px-6 py-24">
         <div className="grid gap-10 lg:grid-cols-4 lg:items-center lg:gap-4">
           <div className="flex justify-center" data-animate="hero-photo">

--- a/src/components/ui/ProjectsShowcase.tsx
+++ b/src/components/ui/ProjectsShowcase.tsx
@@ -93,7 +93,7 @@ export function ProjectsShowcase({ projects }: ProjectsShowcaseProps) {
   return (
     <section
       id="projects"
-      className="scroll-mt-32 flex min-h-screen flex-col justify-center border-b border-aluminum-500/20 bg-charcoal-900">
+      className="scroll-mt-32 flex min-h-screen flex-col justify-center border-b border-aluminum-500/20 bg-transparent">
       <div className="mx-auto w-full max-w-5xl px-6 py-16">
         <div className="max-w-3xl space-y-4" data-animate="section-heading">
           <h2 className="text-3xl font-semibold text-aluminum-100">Projects</h2>
@@ -102,24 +102,22 @@ export function ProjectsShowcase({ projects }: ProjectsShowcaseProps) {
         <div className="mt-10 space-y-6" data-animate="section-heading">
           <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4">
             <span className="text-xs font-semibold uppercase tracking-[0.3em] text-aluminum-400">Sort</span>
-            <div className="flex flex-wrap gap-x-4 gap-y-2">
+            <div className="flex flex-wrap gap-2">
               {SORTS.map((s) => (
                 <button
                   key={s}
                   type="button"
                   aria-pressed={sort === s}
                   onClick={() => setSort(s)}
-                  className={`text-xs font-semibold uppercase tracking-[0.25em] transition ${
-                    sort === s ? 'text-ember-200 underline underline-offset-4' : 'text-aluminum-400 hover:text-aluminum-200'
-                  }`}>
+                  className={pillClass(sort === s)}>
                   {s.charAt(0).toUpperCase() + s.slice(1)}
                 </button>
               ))}
             </div>
           </div>
 
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:gap-4">
-            <span className="mt-1 text-xs font-semibold uppercase tracking-[0.3em] text-aluminum-400">Filter</span>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+            <span className="text-xs font-semibold uppercase tracking-[0.3em] text-aluminum-400">Filter</span>
             <div className="flex flex-wrap gap-2">
               <button
                 type="button"

--- a/src/components/ui/StarsBackground.stories.tsx
+++ b/src/components/ui/StarsBackground.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { StarsBackground } from './StarsBackground';
+
+const meta = {
+  title: 'UI/StarsBackground',
+  component: StarsBackground,
+  parameters: { layout: 'fullscreen' },
+  // Give the backdrop a sized, relatively-positioned stage to fill.
+  decorators: [
+    (Story) => (
+      <div className="relative min-h-[70vh] bg-charcoal-900 text-aluminum-100">{Story()}</div>
+    ),
+  ],
+  args: {
+    className: 'absolute inset-0',
+    factor: 0.05,
+    speed: 50,
+  },
+} satisfies Meta<typeof StarsBackground>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Backdrop usage with foreground content layered on top. Move the cursor to see the parallax. */
+export const Default: Story = {
+  args: {
+    children: (
+      <div className="relative flex min-h-[70vh] flex-col items-center justify-center gap-3 px-6 text-center">
+        <span className="inline-flex items-center rounded-full border border-ember-400/30 bg-ember-500/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.4em] text-ember-200">
+          Stars background
+        </span>
+        <h2 className="text-4xl font-semibold text-aluminum-100">Move your cursor</h2>
+        <p className="max-w-md text-aluminum-300">
+          Three drifting layers with a spring-like pointer parallax. Pauses for reduced-motion users.
+        </p>
+      </div>
+    ),
+  },
+};
+
+/** Slower drift with a stronger parallax pull. */
+export const SlowAndDeep: Story = {
+  args: { speed: 90, factor: 0.12 },
+};
+
+/** Parallax disabled — pure drift only. */
+export const NoParallax: Story = {
+  args: { factor: 0 },
+};

--- a/src/components/ui/StarsBackground.tsx
+++ b/src/components/ui/StarsBackground.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from 'react';
+import gsap from 'gsap';
+
+export interface StarsBackgroundProps {
+  /** Extra classes on the root — e.g. `fixed inset-0 z-[-10]` for a page backdrop. */
+  className?: string;
+  /** Pointer-parallax strength. `0` disables the parallax entirely. */
+  factor?: number;
+  /** Seconds for the base (smallest) layer to drift one full loop. Larger = slower. */
+  speed?: number;
+  /** Star colour. Defaults to `currentColor` so it follows the active theme via CSS. */
+  starColor?: string;
+  /** Whether the root captures pointer events. The decorative layers never do. */
+  pointerEvents?: boolean;
+  children?: ReactNode;
+}
+
+interface LayerConfig {
+  count: number;
+  /** Star diameter in px. */
+  size: number;
+  /** Drift duration in seconds. */
+  duration: number;
+}
+
+// Field the stars are scattered across. The loop height is fixed at LOOP_PX so a
+// duplicated block one loop-height down can seamlessly wrap as the layer drifts.
+const LOOP_PX = 2000;
+const SPREAD_X = 3000;
+
+function generateBoxShadow(count: number, color: string): string {
+  const shadows: string[] = [];
+  for (let i = 0; i < count; i += 1) {
+    const x = Math.floor(Math.random() * SPREAD_X);
+    const y = Math.floor(Math.random() * LOOP_PX);
+    shadows.push(`${x}px ${y}px ${color}`);
+  }
+  return shadows.join(', ');
+}
+
+/**
+ * One depth layer: a single 1px element whose `box-shadow` paints `count` copies
+ * of itself (cheap — the browser rasterises the whole field once, then we only
+ * GPU-transform it). The layer is duplicated LOOP_PX down so the linear drift in
+ * the `stars-drift` keyframe wraps without a visible seam.
+ */
+function StarLayer({ count, size, duration, color }: LayerConfig & { color: string }) {
+  // Generated after mount so a server/client render mismatch is impossible and
+  // Math.random never runs during SSR.
+  const [boxShadow, setBoxShadow] = useState('');
+  useEffect(() => {
+    setBoxShadow(generateBoxShadow(count, color));
+  }, [count, color]);
+
+  const star: CSSProperties = { width: size, height: size, boxShadow };
+
+  return (
+    <div className="stars-bg__layer" style={{ animationDuration: `${duration}s` }}>
+      <div className="stars-bg__star" style={star} />
+      <div className="stars-bg__star" style={{ ...star, top: LOOP_PX }} />
+    </div>
+  );
+}
+
+/**
+ * Animated star-field background. Three parallax layers of drifting dots over a
+ * transparent surface, with a spring-like pointer parallax driven by GSAP. Drop
+ * it behind content as a `fixed inset-0 z-[-10]` backdrop, or wrap content with
+ * it directly. Decorative — hidden from assistive tech and fully disabled under
+ * `prefers-reduced-motion`.
+ *
+ * Inspired by animate-ui's Stars background, re-implemented on the site's own
+ * stack (GSAP + CSS) so it needs no extra animation dependency.
+ */
+export function StarsBackground({
+  className,
+  factor = 0.05,
+  speed = 50,
+  starColor = 'currentColor',
+  pointerEvents = true,
+  children,
+}: StarsBackgroundProps) {
+  const parallaxRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = parallaxRef.current;
+    if (!el || factor === 0) return;
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+    const xTo = gsap.quickTo(el, 'x', { duration: 0.7, ease: 'power3.out' });
+    const yTo = gsap.quickTo(el, 'y', { duration: 0.7, ease: 'power3.out' });
+
+    const onMove = (event: PointerEvent) => {
+      const cx = window.innerWidth / 2;
+      const cy = window.innerHeight / 2;
+      xTo(-(event.clientX - cx) * factor);
+      yTo(-(event.clientY - cy) * factor);
+    };
+
+    window.addEventListener('pointermove', onMove, { passive: true });
+    return () => {
+      window.removeEventListener('pointermove', onMove);
+      gsap.killTweensOf(el);
+    };
+  }, [factor]);
+
+  return (
+    <div
+      aria-hidden="true"
+      className={`stars-bg${className ? ` ${className}` : ''}`}
+      style={pointerEvents ? undefined : { pointerEvents: 'none' }}>
+      <div ref={parallaxRef} className="stars-bg__parallax">
+        <StarLayer count={600} size={1} duration={speed} color={starColor} />
+        <StarLayer count={200} size={2} duration={speed * 2} color={starColor} />
+        <StarLayer count={100} size={3} duration={speed * 3} color={starColor} />
+      </div>
+      {children}
+    </div>
+  );
+}
+
+export default StarsBackground;

--- a/src/components/ui/Tag.tsx
+++ b/src/components/ui/Tag.tsx
@@ -6,11 +6,15 @@ interface TagProps {
   children: ReactNode;
 }
 
-/** Small graphite pill used for technology lists and similar metadata. */
+/**
+ * Small outlined pill used for technology lists and similar metadata. The
+ * `tech-chip` hook wires it into the shared reading-emphasis rules in global.css
+ * (resting aluminum-200 → full contrast on hover / in high-contrast mode).
+ */
 export function Tag({ as: Tag = 'span', className = '', children }: TagProps) {
   return (
     <Tag
-      className={`rounded-full border border-aluminum-500/30 bg-graphite-700/70 px-3 py-1 text-xs font-medium text-aluminum-200 ${className}`.trim()}>
+      className={`tech-chip rounded-full border border-aluminum-500/30 px-3 py-1 text-xs font-medium text-aluminum-200 ${className}`.trim()}>
       {children}
     </Tag>
   );

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -16,6 +16,8 @@ export { ProjectCard } from './ProjectCard';
 export { Hero } from './Hero';
 export { ContactSection } from './ContactSection';
 export { ProjectsShowcase } from './ProjectsShowcase';
+export { StarsBackground } from './StarsBackground';
+export type { StarsBackgroundProps } from './StarsBackground';
 export { ExternalLinkIcon } from './icons';
 // Preview-only wrapper for design-sync (excluded from the synced set).
 export { ThemeFrame } from './ThemeFrame';

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,6 +1,7 @@
 ---
 import '../styles/global.css';
 import { site } from '../data/site';
+import { StarsBackground } from '../components/ui/StarsBackground';
 
 interface Props {
   title?: string;
@@ -85,7 +86,11 @@ const currentYear = new Date().getFullYear();
       _gs('set', 'anonymizeIP', true);
     </script>
   </head>
-  <body class="flex min-h-screen flex-col bg-charcoal-900 text-aluminum-100 antialiased">
+  <body class="flex min-h-screen flex-col text-aluminum-100 antialiased">
+    <!-- Site-wide drifting star field. Fixed behind all content (z-[-10]); the
+         charcoal body background shows through the gaps. Decorative + inert, so
+         it never intercepts clicks. client:only avoids an SSR/Math.random flash. -->
+    <StarsBackground client:only="react" className="fixed inset-0 z-[-10]" pointerEvents={false} />
     <a
       class="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:rounded-md focus:bg-aluminum-100 focus:px-4 focus:py-2 focus:text-charcoal-900"
       href="#main">Skip to content</a

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -19,7 +19,7 @@ function fmtFull(d?: Date | string): string {
 ---
 
 <BaseLayout title={title} description={description} type="article">
-  <article class="bg-charcoal-900 py-16 text-aluminum-100">
+  <article class="bg-transparent py-16 text-aluminum-100">
     <div class="mx-auto max-w-3xl px-6">
       <header class="space-y-3">
         {date && <p class="text-xs font-semibold uppercase text-aluminum-400">{fmtFull(date)}</p>}

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -24,8 +24,8 @@ const hasUpdates = (data.updates?.length ?? 0) > 0;
 ---
 
 <BaseLayout title={data.title} description={data.description} type="article" image={data.image}>
-  <article class="bg-charcoal-900 text-aluminum-100">
-    <section class="border-b border-aluminum-500/25 bg-charcoal-900">
+  <article class="bg-transparent text-aluminum-100">
+    <section class="border-b border-aluminum-500/25 bg-transparent">
       <div class="mx-auto max-w-5xl px-6 py-20">
         <a
           class="text-sm text-aluminum-300 underline underline-offset-4 transition hover:text-ember-300 hover:underline"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -43,7 +43,7 @@ const navItems = ['experience', 'capabilities', 'education', 'projects', 'contac
 
   <section
     id="experience"
-    class="scroll-mt-32 flex min-h-screen flex-col justify-center border-b border-aluminum-500/20 bg-charcoal-900">
+    class="scroll-mt-32 flex min-h-screen flex-col justify-center border-b border-aluminum-500/20 bg-transparent">
     <div class="mx-auto w-full max-w-5xl px-6 py-16">
       <SectionHeading
         title="Experience"
@@ -57,7 +57,7 @@ const navItems = ['experience', 'capabilities', 'education', 'projects', 'contac
 
   <section
     id="capabilities"
-    class="scroll-mt-32 flex min-h-screen flex-col justify-center border-b border-aluminum-500/20 bg-charcoal-900">
+    class="scroll-mt-32 flex min-h-screen flex-col justify-center border-b border-aluminum-500/20 bg-transparent">
     <div class="mx-auto w-full max-w-5xl px-6 py-16">
       <SectionHeading
         title="Core capabilities"
@@ -71,7 +71,7 @@ const navItems = ['experience', 'capabilities', 'education', 'projects', 'contac
 
   <section
     id="education"
-    class="scroll-mt-32 flex min-h-screen flex-col justify-center border-b border-aluminum-500/20 bg-charcoal-900">
+    class="scroll-mt-32 flex min-h-screen flex-col justify-center border-b border-aluminum-500/20 bg-transparent">
     <div class="mx-auto w-full max-w-5xl px-6 py-16">
       <SectionHeading
         title="Education & Certifications"

--- a/src/scripts/scroll-animations.ts
+++ b/src/scripts/scroll-animations.ts
@@ -214,23 +214,13 @@ ready(function () {
 
     cards.forEach((card, index) => {
       const fromX = index % 2 === 0 ? -32 : 32;
-      gsap.set(card, { x: fromX, opacity: 0, transformOrigin: '50% 50%' });
-
-      const hoverTimeline = gsap
-        .timeline({ paused: true, defaults: { ease: 'power2.out' } })
-        .to(card, { y: -12, scale: 1.02, boxShadow: '0 28px 55px -30px rgba(255, 176, 122, 0.6)', duration: 0.35 }, 0);
+      gsap.set(card, { x: fromX, opacity: 0 });
 
       const reveal = () => {
-        hoverTimeline.progress(0).pause();
         gsap.to(card, { x: 0, opacity: 1, duration: 0.6, ease: 'power1.out' });
       };
 
       ScrollTrigger.create({ trigger: card, start: 'top 85%', onEnter: reveal, onEnterBack: reveal });
-
-      card.addEventListener('mouseenter', () => hoverTimeline.play());
-      card.addEventListener('mouseleave', () => hoverTimeline.reverse());
-      card.addEventListener('focusin', () => hoverTimeline.play());
-      card.addEventListener('focusout', () => hoverTimeline.reverse());
     });
   }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -75,9 +75,16 @@
 }
 
 @layer base {
-  body {
-    @apply bg-charcoal-900 text-aluminum-100 antialiased;
+  /* The base/page colour lives on the <html> canvas (painted at the very back)
+     rather than <body>, so the fixed z-[-10] star field (a negative-z child of
+     body) is not occluded by an opaque body background. body stays transparent. */
+  html {
+    @apply bg-charcoal-900;
     background-attachment: fixed;
+  }
+
+  body {
+    @apply text-aluminum-100 antialiased;
   }
 
   a {
@@ -328,6 +335,41 @@
     stroke-opacity: 0.5;
   }
 
+  /* ── Stars background ───────────────────────────────────────────────────────
+     Drifting box-shadow star field (see StarsBackground.tsx). Star colour rides
+     `currentColor` so it swaps per theme: bright on the dark surface, a soft grey
+     pinprick on the near-white light surface (white stars would vanish there). */
+  .stars-bg {
+    position: relative;
+    overflow: hidden;
+    color: rgb(var(--aluminum-100) / 0.55);
+  }
+  :root[data-theme="light"] .stars-bg {
+    color: rgb(var(--aluminum-400) / 0.75);
+  }
+  .stars-bg__parallax {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    will-change: transform;
+  }
+  .stars-bg__layer {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 2000px;
+    animation: stars-drift linear infinite;
+    will-change: transform;
+  }
+  .stars-bg__star {
+    position: absolute;
+    top: 0;
+    left: 0;
+    background: transparent;
+    border-radius: 9999px;
+  }
+
   /* ── Updates timeline (project case-study pages) ────────────────────────────── */
   .update-timeline {
     border-left: 1px solid rgb(var(--ember-400) / 0.3);
@@ -414,4 +456,115 @@
 a[class*='hover:']:not([class*='hover:underline']):hover,
 a[class*='hover:']:not([class*='hover:underline']):focus-visible {
   text-decoration-line: none;
+}
+
+/* Stars-background drift (kept top-level so it is never trapped behind a cascade
+   layer). The layer translates exactly one loop-height up; a second star block
+   stacked one loop-height down keeps the field seamless as it wraps. */
+@keyframes stars-drift {
+  from { transform: translate3d(0, 0, 0); }
+  to { transform: translate3d(0, -2000px, 0); }
+}
+
+/* Respect reduced-motion: hold the field still (the GSAP parallax is skipped in
+   the component under the same query). */
+@media (prefers-reduced-motion: reduce) {
+  .stars-bg__layer { animation: none; }
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+   Reading emphasis (UNLAYERED — intentional)
+
+   Secondary body copy, meta labels, section bullet lists and the technology
+   chips — grey `p.text-aluminum-300`, the smaller `.text-aluminum-400` meta
+   labels (eyebrows, dates, captions; scoped to non-interactive text tags so it
+   never touches the aluminum-400 sort buttons or the footer container), the
+   bullets inside grey lists (`ul/ol.text-aluminum-300 > li`, e.g. experience
+   highlights and project features), the `.tech-chip` pills (resting
+   aluminum-200), plus the case-study/blog `.prose-invert` body — keep their
+   dimmer resting colour so the title → body → meta colour hierarchy survives,
+   but ease to full title contrast on hover for reading focus. Prose tracks both
+   themes via the typography colour variables (`--tw-prose-headings`).
+
+   Unlayered so it beats the `text-aluminum-*` and @tailwindcss/typography
+   utilities — both compile into the `utilities` layer, which is LAST in the
+   cascade, so a layered override would silently lose (see the cascade-layer note
+   above). The resting grey already clears WCAG 2.1 AA, so hover is enhancement
+   only; under `prefers-contrast: more` we surface full contrast by default so no
+   one depends on hovering. Hover is gated to hover-capable pointers so touch
+   devices never stick in the emphasised state.
+   ────────────────────────────────────────────────────────────────────────── */
+p.text-aluminum-300,
+:where(p, span, figcaption, dt, dd, time).text-aluminum-400,
+:where(ul, ol).text-aluminum-300 > li,
+.tech-chip,
+.prose-invert :where(p, li) {
+  transition: color 0.3s ease;
+}
+
+@media (hover: hover) {
+  p.text-aluminum-300:hover,
+  :where(p, span, figcaption, dt, dd, time).text-aluminum-400:hover,
+  :where(ul, ol).text-aluminum-300 > li:hover,
+  .tech-chip:hover {
+    color: rgb(var(--aluminum-100));
+  }
+  .prose-invert :where(p, li):hover {
+    color: var(--tw-prose-headings);
+  }
+}
+
+/* Heading-group hover (UNLAYERED, hover-capable pointers only).
+
+   Hovering a section/hero heading (h1/h2) lights ALL of that section's secondary
+   content at once; hovering a card sub-heading (h3) lights just that card. The
+   descendants reuse the same emphasis targets as the per-element rules above and
+   already carry the colour transition, so the whole group eases up together.
+   `:has()` is Baseline-2023 — older browsers simply keep the per-element hover.
+   Prose headings are excluded by construction: their paragraphs live in a
+   `.detail-content`/`<article>`, not a `<section>`, and lighting a whole article
+   on a single heading hover would be too much. */
+@media (hover: hover) {
+  :is(section:has(:where(h1, h2):hover), .surface-panel:has(:where(h2, h3):hover)) p.text-aluminum-300,
+  :is(section:has(:where(h1, h2):hover), .surface-panel:has(:where(h2, h3):hover)) :where(p, span, figcaption, dt, dd, time).text-aluminum-400,
+  :is(section:has(:where(h1, h2):hover), .surface-panel:has(:where(h2, h3):hover)) :where(ul, ol).text-aluminum-300 > li,
+  :is(section:has(:where(h1, h2):hover), .surface-panel:has(:where(h2, h3):hover)) .tech-chip {
+    color: rgb(var(--aluminum-100));
+  }
+
+  /* The eyebrow sub-labels ("Core technologies", "Key features") act as the
+     heading for their immediately-following list: hovering the label lights its
+     chips or feature bullets, which sit as siblings inside the same group div. */
+  p.text-aluminum-400:hover ~ ul > li {
+    color: rgb(var(--aluminum-100));
+  }
+
+  /* The "Filter" eyebrow label lights its category chips. Those chips are
+     <button>s (in a sibling <div>), and only the inactive ones (text-aluminum-300)
+     are targeted, so the active/selected ember pill keeps its state. */
+  span.text-aluminum-400:hover ~ div button.text-aluminum-300 {
+    color: rgb(var(--aluminum-100));
+  }
+}
+
+@media (prefers-contrast: more) {
+  p.text-aluminum-300,
+  :where(p, span, figcaption, dt, dd, time).text-aluminum-400,
+  :where(ul, ol).text-aluminum-300 > li,
+  .tech-chip {
+    color: rgb(var(--aluminum-100));
+  }
+  .prose-invert :where(p, li) {
+    color: var(--tw-prose-headings);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  p.text-aluminum-300,
+  :where(p, span, figcaption, dt, dd, time).text-aluminum-400,
+  :where(ul, ol).text-aluminum-300 > li,
+  .tech-chip,
+  .prose-invert :where(p, li) {
+    transition: none;
+  }
 }


### PR DESCRIPTION
## Summary
A site-wide animated star-field background plus a set of hover/UI refinements.

### Background
- New **`StarsBackground`** component (GSAP pointer-parallax + CSS box-shadow star layers, theme-aware via `currentColor`, `prefers-reduced-motion` safe) mounted as a fixed `z-[-10]` backdrop in `BaseLayout`; ships with Storybook stories.
- Base charcoal colour moved from `<body>` to the `<html>` canvas so the negative-z fixed field isn't occluded; homepage and case-study sections made transparent so it shows through.
- Dark-mode stars subtler (`0.55`), light-mode more prominent (`0.75`).

### Reading emphasis
- Secondary body copy, meta labels, section bullets, technology chips and prose body keep their grey resting colour but ease to full title contrast on hover; default to full contrast under `prefers-contrast: more`; hover-capable pointers only; instant under reduced-motion.
- Heading-group hover via `:has()` — a section/hero heading lights the whole section, a card sub-heading lights its card, and the “Core technologies” / “Key features” / “Filter” eyebrow labels light their lists.

### UI
- Technology chips lose their graphite fill (outline pills).
- Projects: Sort options now use the same chip styles as Filter; both rows vertically centre their label with their options.
- Project cards: hover scale, lift and ember drop-shadow removed — they now hover identically to the other `.surface-panel` cards (ember border + spotlight).

## Verification
- `npm run build` passes (16 pages); no console errors in preview.
- Verified across dark/light themes and structural checks for the hover groupings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)