### PR TITLE
Add Claude Usage Pacer to projects showcase

### DIFF
--- a/public/assets/images/projects/claude-usage-pacer-icon.svg
+++ b/public/assets/images/projects/claude-usage-pacer-icon.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-labelledby="up-icon-title">
+  <title id="up-icon-title">Claude Usage Pacer app icon</title>
+  <defs>
+    <radialGradient id="up-icon-bg" cx="42%" cy="40%" r="78%">
+      <stop offset="0%" stop-color="#33251f"/>
+      <stop offset="64%" stop-color="#221a16"/>
+      <stop offset="100%" stop-color="#181210"/>
+    </radialGradient>
+    <radialGradient id="up-icon-core" cx="38%" cy="34%" r="72%">
+      <stop offset="0%" stop-color="#fce3c8"/>
+      <stop offset="36%" stop-color="#f3b184"/>
+      <stop offset="66%" stop-color="#cc785c"/>
+      <stop offset="100%" stop-color="#9c5236"/>
+    </radialGradient>
+    <linearGradient id="up-icon-week" x1="46" y1="46" x2="172" y2="172" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#9c5236"/>
+      <stop offset="55%" stop-color="#cc785c"/>
+      <stop offset="100%" stop-color="#f0b48c"/>
+    </linearGradient>
+    <linearGradient id="up-icon-five" x1="70" y1="70" x2="175" y2="175" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#cc785c"/>
+      <stop offset="60%" stop-color="#f3b184"/>
+      <stop offset="100%" stop-color="#f9dcc3"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="256" height="256" rx="56" fill="url(#up-icon-bg)"/>
+
+  <!-- Outer ring: the weekly cap -->
+  <circle cx="128" cy="128" r="82" fill="none" stroke="#f3ebde" stroke-opacity="0.12" stroke-width="9"/>
+  <path d="M128 46 A82 82 0 1 1 58.8 172" fill="none" stroke="url(#up-icon-week)" stroke-width="9" stroke-linecap="round"/>
+
+  <!-- Inner ring: the rolling five-hour window -->
+  <circle cx="128" cy="128" r="58" fill="none" stroke="#f3ebde" stroke-opacity="0.12" stroke-width="9"/>
+  <path d="M128 70 A58 58 0 0 1 162.1 174.9" fill="none" stroke="url(#up-icon-five)" stroke-width="9" stroke-linecap="round"/>
+
+  <!-- Target tick on the weekly ring: the reserve we hold back to -->
+  <line x1="59.5" y1="105.8" x2="40.5" y2="99.6" stroke="#fbeede" stroke-opacity="0.9" stroke-width="4" stroke-linecap="round"/>
+
+  <!-- Ember core -->
+  <circle cx="128" cy="128" r="34" fill="#cc785c" opacity="0.18"/>
+  <circle cx="128" cy="128" r="24" fill="url(#up-icon-core)"/>
+  <ellipse cx="121" cy="120" rx="8" ry="4.5" fill="#fdeee0" opacity="0.55"/>
+</svg>

--- a/src/data/app_projects.yml
+++ b/src/data/app_projects.yml
@@ -120,10 +120,45 @@
     - Self-authored job-application-tracking MCP that orchestrates the full lifecycle of an application from JD analysis through draft management.
     - "Self-improving skills: internal performance tracking informs external skill and tool research so the system iterates on its own deployment patterns over time."
 
+- name: Claude Usage Pacer
+  platform: Personal Applied AI · macOS menu bar
+  status: Live, daily use
+  order: 5
+  date_started: "2026-06"
+  tags: [applied-ai, python, personal, macos]
+  icon: /assets/images/projects/claude-usage-pacer-icon.svg
+  link: /projects/claude-usage-pacer/
+  link_label: Read the case study
+  audience: A macOS menu bar tool that paces a Claude Max subscription against both its reset cycles — the rolling five-hour window and the weekly cap — aiming for near-full use while holding a reserve, and telling me across my devices exactly when I am locked out and when I can resume.
+  summary: >
+    The Usage Pacer reads Claude's authoritative usage API — the same figures the
+    official screen shows, via the Claude Code token in the macOS Keychain — and
+    models burn-down against my actual working hours, so a Max plan gets used
+    nearly in full instead of leaving a third of the week unspent. Capacity splits
+    in two: attended windows I run by hand, and harvestable windows that scheduled
+    overnight work can soak up. A colour-coded two-clock menu bar readout shows
+    both limits at a glance, and when a window genuinely maxes out it drops a synced
+    iCloud calendar reminder and sends one quiet, de-duplicated message telling me
+    when usage resumes. It reads nothing it cannot cite, and shows a dash rather
+    than a wrong number when its undocumented data source breaks — the lesson the
+    off-the-shelf tool it replaced taught when it failed silently.
+  technologies:
+    - Python (AI-paired)
+    - Claude OAuth usage API
+    - macOS menu bar · Keychain
+    - Scheduled overnight harvest
+    - iCloud Calendar · cross-device alerts
+  features:
+    - "Reads the authoritative source, never a guess: the five-hour and weekly limits come straight from Claude's OAuth usage API via the Keychain token, so the numbers match the official screen with no scraping."
+    - "Paces against real working hours: a burn-down model splits the week into attended windows run by hand and harvestable windows that scheduled overnight work soaks up, so the plan gets used nearly in full without overshooting."
+    - "Closes the loop on lockout: when a window genuinely maxes, it drops a synced iCloud calendar reminder and sends one quiet, de-duplicated cross-device message saying exactly when usage resumes, and stays silent overnight."
+    - "Honest by design: a colour-coded two-clock menu bar readout, and a hard rule that it shows a dash rather than a wrong number when its undocumented data source breaks."
+    - "Caught by a test, not in production: a fixed-clock scenario test caught a burn-rate projection bug that flipped the status to over at eight percent of the week; the fix refuses to trust a rate until an hour of history backs it."
+
 - name: Peaking
   platform: iOS
   status: Active development
-  order: 5
+  order: 6
   date_started: "2024-06"
   tags: [swift, ios, mapkit, cloudkit, personal]
   audience: For hikers and mountaineers who track summits, routes, and collection progress.
@@ -152,7 +187,7 @@
 - name: Training
   platform: iOS
   status: Active development
-  order: 6
+  order: 7
   date_started: "2025-01"
   tags: [swift, ios, healthkit, personal]
   audience: For athletes, coaches, and habit-focused users who want stronger training consistency.
@@ -176,7 +211,7 @@
 
 - name: Squash Tracker
   platform: iOS & watchOS
-  order: 7
+  order: 8
   date_started: "2025-03"
   tags: [swift, ios, watchos, healthkit, personal]
   audience: For squash players who want to record matches, track scores, and review performance over time.


### PR DESCRIPTION
## Problem

The **Claude Usage Pacer** case study built fine and was reachable at `/projects/claude-usage-pacer/`, but it didn't appear anywhere on the published site. The homepage Projects grid is driven by `src/data/app_projects.yml` (via `ProjectsShowcase`), and the project had **no entry there** — so no card linked to it.

## Fix

- Add a `Claude Usage Pacer` entry to `app_projects.yml` at `order: 5` (after LifeOS), with platform, status, tags, summary, technologies and feature bullets drawn from the case study.
- Bump Peaking / Training / Squash Tracker to `order` 6 / 7 / 8 so the sequence stays contiguous.
- Add a matching dual-ring gauge icon (`claude-usage-pacer-icon.svg`) so the card doesn't fall back to the generic `✦` placeholder tile.

## Verification

`astro build` passes. The built `dist/index.html` includes the card:
- ✅ "Claude Usage Pacer" present, linking to `/projects/claude-usage-pacer/`
- ✅ Icon referenced and copied into the build
- ✅ Order: Career Pivot → Open Defence Radar → PodForge → LifeOS → **Claude Usage Pacer** → Peaking → Training → Squash Tracker

🤖 Generated with [Claude Code](https://claude.com/claude-code)