### PR TITLE
fix(case-study): full-width tables/insets in project body

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -191,15 +191,11 @@
     margin-top: 0.5em;
   }
 
-  /* Project-page content widths: lift the 65ch prose cap off the container so
-     bounded media (figures, tables, the architecture diagram) fill the column,
-     and re-apply the reading width only to text body elements. */
-  .detail-content {
-    max-width: none;
-  }
-  .detail-content :where(p, ul, ol, blockquote, dl):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
-    max-width: 65ch;
-  }
+  /* NOTE: the `.detail-content` content-width overrides (lift the 65ch cap off
+     the container; re-cap only text body elements) live UNLAYERED further down —
+     see "Case-study content widths". @tailwindcss/typography's `.prose` sets
+     `max-width: 65ch` from the `utilities` layer, so a layered `.detail-content`
+     rule can never win regardless of specificity. */
 
   /* Page-nav scroll bleed: scroll viewport spans the full nav width, but dynamic
      padding aligns the first/last pill with the content column edges
@@ -477,6 +473,24 @@
   --tw-prose-pre-bg: rgb(var(--graphite-700));
   --tw-prose-th-borders: rgb(var(--aluminum-500) / 0.3);
   --tw-prose-td-borders: rgb(var(--aluminum-500) / 0.2);
+}
+
+/* Case-study content widths (UNLAYERED — intentional, same reason as above).
+
+   Lift the 65ch reading cap off the `.detail-content` container so bounded media
+   (figures, tables, the architecture diagram, surface-panel asides) fill the
+   full max-w-5xl column, then re-apply the reading width only to text body
+   elements. @tailwindcss/typography's `.prose` sets `max-width: 65ch` on the
+   container from the `utilities` layer; a layered override silently loses (it
+   previously sat in @layer components, capping every inset object to the text
+   column — the exact bug this block fixes), so these sit unlayered to win. The
+   UpdateTimeline body reaches the same result via an explicit `max-w-none`
+   utility, which is why the Updates section was already full-width. */
+.detail-content {
+  max-width: none;
+}
+.detail-content :where(p, ul, ol, blockquote, dl):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+  max-width: 65ch;
 }
 
 /* Primary CTA hover in light mode. The hover:bg-ember-300 utility yields a


### PR DESCRIPTION
## Summary
- Case-study body insets (tables, figures, `<aside>` panels, the architecture diagram) were clipped to the 65ch text column instead of filling the full `max-w-5xl` content width.
- Root cause: `.detail-content { max-width: none }` lived in `@layer components`, which loses to `@tailwindcss/typography`'s `.prose { max-width: 65ch }` in the later `utilities` layer — so the whole container computed `max-width: 655px`. (The Updates timeline was unaffected because it adds an explicit `max-w-none` utility.)
- Fix: moved the `.detail-content` width overrides **unlayered**, matching this repo's documented pattern for beating the typography plugin. The container now fills the full column while only text elements (`p, ul, ol, blockquote, dl`) re-cap to the 65ch reading width.

## Test plan
- [x] `getComputedStyle('.detail-content').maxWidth` → `none` (was `655px`); paragraphs stay `655px` — verified on `/projects/claude-usage-pacer/` and `/projects/lifeos/`.
- [x] Tables and `not-prose` figures compute `max-width: none` (free to fill the column).
- [x] `npm run build` passes — all 19 pages built, no CSS/console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)