### PR TITLE
Self-host typography (Fraunces / Hanken Grotesk / JetBrains Mono)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,5 @@
 // @ts-check
-import { defineConfig } from 'astro/config';
+import { defineConfig, fontProviders } from 'astro/config';
 import react from '@astrojs/react';
 import mdx from '@astrojs/mdx';
 import sitemap from '@astrojs/sitemap';
@@ -16,6 +16,42 @@ export default defineConfig({
   redirects: {
     '/2023/07/01/coaching-design-teams/': '/posts/coaching-design-teams/',
   },
+  // Self-hosted typography via the stable Astro Fonts API. Downloaded and
+  // cached at build so fonts serve from our own domain (privacy + CWV), with
+  // preload links and metric-matched fallbacks generated automatically.
+  // Consumed in CSS through the --ff-* variables (see global.css @theme).
+  //   --ff-display → Fraunces      (headings; editorial variable serif)
+  //   --ff-body    → Hanken Grotesk (body/UI; humanist grotesque)
+  //   --ff-mono    → JetBrains Mono (labels, code)
+  fonts: [
+    {
+      provider: fontProviders.google(),
+      name: 'Fraunces',
+      cssVariable: '--ff-display',
+      weights: [400, 600, 700, 900],
+      styles: ['normal'],
+      subsets: ['latin'],
+      fallbacks: ['Georgia', 'Cambria', 'Times New Roman', 'serif'],
+    },
+    {
+      provider: fontProviders.google(),
+      name: 'Hanken Grotesk',
+      cssVariable: '--ff-body',
+      weights: [400, 500, 600, 700],
+      styles: ['normal'],
+      subsets: ['latin'],
+      fallbacks: ['-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'sans-serif'],
+    },
+    {
+      provider: fontProviders.google(),
+      name: 'JetBrains Mono',
+      cssVariable: '--ff-mono',
+      weights: [500, 600],
+      styles: ['normal'],
+      subsets: ['latin'],
+      fallbacks: ['SF Mono', 'Menlo', 'Consolas', 'monospace'],
+    },
+  ],
   integrations: [react(), mdx(), sitemap()],
   vite: {
     plugins: [yaml(), tailwindcss()],

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,5 +1,6 @@
 ---
 import '../styles/global.css';
+import { Font } from 'astro:assets';
 import { site } from '../data/site';
 import { StarsBackground } from '../components/ui/StarsBackground';
 
@@ -28,6 +29,13 @@ const currentYear = new Date().getFullYear();
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+    <!-- Self-hosted fonts (Astro Fonts API). Display + body preloaded for LCP;
+         mono is non-critical so it loads without a preload hint. -->
+    <Font cssVariable="--ff-display" preload />
+    <Font cssVariable="--ff-body" preload />
+    <Font cssVariable="--ff-mono" />
+
     <title>{fullTitle}</title>
     <meta name="description" content={description} />
     <link rel="canonical" href={canonicalURL} />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -72,6 +72,13 @@
   --color-ember-600: rgb(var(--ember-600));
 
   --shadow-glow: 0 20px 40px -20px rgba(0, 0, 0, 0.6);
+
+  /* Typography. Families resolve to the self-hosted faces injected at :root by
+     the Astro Fonts API (the --ff-* vars). Registering them here gives the
+     Tailwind `font-sans` / `font-display` / `font-mono` utilities too. */
+  --font-sans: var(--ff-body);
+  --font-display: var(--ff-display);
+  --font-mono: var(--ff-mono);
 }
 
 @layer base {
@@ -85,6 +92,22 @@
 
   body {
     @apply text-aluminum-100 antialiased;
+    font-family: var(--ff-body, ui-sans-serif, system-ui, sans-serif);
+  }
+
+  /* Headings carry the editorial serif; weight utilities (font-semibold etc.)
+     still win from the utilities layer, so only the family is set here. */
+  h1,
+  h2,
+  h3 {
+    font-family: var(--ff-display, Georgia, Cambria, serif);
+  }
+
+  code,
+  kbd,
+  samp,
+  pre {
+    font-family: var(--ff-mono, ui-monospace, SFMono-Regular, monospace);
   }
 
   a {


### PR DESCRIPTION
## Summary
- Ship real, self-hosted fonts via the stable **Astro 6 Fonts API** — the site previously declared `Styrene B`/`Inter` but loaded neither, so every visitor saw system fonts (the biggest "default template" tell).
- **Fraunces** (display serif) on headings, **Hanken Grotesk** for body/UI, **JetBrains Mono** for labels/code. Preloaded `<Font>` tags; mapped to Tailwind `font-sans`/`font-display`/`font-mono`.
- Astro auto-generates metric-matched fallbacks, so there's no layout shift (CLS-safe) as the fonts swap in.

Foundation for the site design improvement epic (#139).

## Test plan
- [x] `<h1>` computes to Fraunces, `body` to Hanken, `code` to JetBrains Mono (verified via dev server)
- [x] All three faces report loaded; hero renders in editorial serif
- [x] Dev server compiles cleanly with no Fonts-API errors
- [ ] Pages deploy succeeds on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)