### PR TITLE
Role-based heading/type system + disable dev toolbar

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -12,6 +12,9 @@ export default defineConfig({
   // Jekyll used pretty permalinks (/projects/name/); keep trailing slashes so
   // existing canonical URLs and inbound links resolve identically.
   trailingSlash: 'always',
+  // Dev-only overlay (island inspector / audits); never ships to production.
+  // Disabled to keep the preview — and screenshots — clean.
+  devToolbar: { enabled: false },
   // Preserve the old Jekyll date-based URL for the one migrated blog post.
   redirects: {
     '/2023/07/01/coaching-design-teams/': '/posts/coaching-design-teams/',

--- a/src/components/UpdateTimeline.astro
+++ b/src/components/UpdateTimeline.astro
@@ -32,19 +32,19 @@ const rendered = sorted.map((u) => ({
 ---
 
 <section id="updates" class="mx-auto max-w-5xl px-6 pb-16">
-  <h2 class="text-2xl font-semibold text-aluminum-100">{label}</h2>
+  <h2 class="type-heading">{label}</h2>
   <ol class="update-timeline mt-8">
     {
       rendered.map((u) => (
         <li id={u.id} class="relative scroll-mt-24">
           <span class="update-timeline__marker" aria-hidden="true" />
           {(u.date || u.version) && (
-            <p class="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.25em] text-aluminum-400">
+            <p class="flex items-center gap-2 eyebrow">
               {u.date && <span>{fmt(u.date)}</span>}
               {u.version && <span class="update-timeline__version">{u.version}</span>}
             </p>
           )}
-          <h3 class="mt-2 text-xl font-semibold text-aluminum-100">
+          <h3 class="mt-2 type-subheading">
             {u.id ? (
               <a class="underline-offset-4 hover:text-ember-300 hover:underline" href={`#${u.id}`}>
                 {u.title}

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -10,7 +10,7 @@ interface BadgeProps {
 export function Badge({ className = '', children }: BadgeProps) {
   return (
     <span
-      className={`inline-flex items-center rounded-full border border-ember-400/30 bg-ember-500/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.4em] text-ember-200 texture-noise ${className}`.trim()}>
+      className={`inline-flex items-center rounded-full border border-ember-400/30 bg-ember-500/10 px-4 py-2 eyebrow text-ember-200 texture-noise ${className}`.trim()}>
       {children}
     </span>
   );

--- a/src/components/ui/CapabilityCard.tsx
+++ b/src/components/ui/CapabilityCard.tsx
@@ -7,7 +7,7 @@ interface CapabilityCardProps {
 export function CapabilityCard({ title, description }: CapabilityCardProps) {
   return (
     <article className="h-full surface-panel p-6 transition-colors duration-200" data-animate="capability-card">
-      <h3 className="text-lg font-semibold leading-tight text-aluminum-100">{title}</h3>
+      <h3 className="type-subheading">{title}</h3>
       <p className="mt-3 text-sm leading-relaxed text-aluminum-300">{description}</p>
     </article>
   );

--- a/src/components/ui/ContactSection.tsx
+++ b/src/components/ui/ContactSection.tsx
@@ -15,7 +15,7 @@ export function ContactSection({ email, linkedin, github }: ContactSectionProps)
           aria-hidden="true"
           className="pointer-events-none absolute inset-x-1/2 top-12 -z-10 h-64 w-[36rem] -translate-x-1/2 rounded-full bg-ember-400/20 blur-[120px] opacity-0"
           data-animate="contact-glow"></div>
-        <h2 className="text-3xl font-semibold text-aluminum-100" data-animate="contact-heading">
+        <h2 className="type-heading" data-animate="contact-heading">
           Let's build momentum together
         </h2>
         <p className="mt-6 text-lg text-aluminum-300" data-animate="contact-copy">

--- a/src/components/ui/EducationPanel.tsx
+++ b/src/components/ui/EducationPanel.tsx
@@ -13,13 +13,13 @@ interface EducationPanelProps {
 export function EducationPanel({ heading, items }: EducationPanelProps) {
   return (
     <div className="space-y-6 surface-panel p-8" data-animate="education-panel">
-      <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-aluminum-300">{heading}</h3>
+      <h3 className="eyebrow">{heading}</h3>
       <ul className="space-y-4 text-sm leading-relaxed text-aluminum-300">
         {items.map((item) => (
           <li key={item.qualification} data-animate="education-item">
             <p className="text-base font-semibold leading-tight text-aluminum-100">{item.qualification}</p>
             <p className="text-sm text-aluminum-300">{item.institution}</p>
-            <p className="mt-1 text-xs font-medium uppercase text-aluminum-400">{item.period}</p>
+            <p className="mt-1 eyebrow">{item.period}</p>
           </li>
         ))}
       </ul>

--- a/src/components/ui/ExperienceCard.tsx
+++ b/src/components/ui/ExperienceCard.tsx
@@ -13,11 +13,11 @@ export function ExperienceCard({ title, company, location, period, highlights }:
       className="surface-panel p-6 shadow-[0_20px_45px_-30px_rgba(0,0,0,0.9)] lg:p-8"
       data-animate="experience-card">
       <div className="space-y-1">
-        <h3 className="text-xl font-semibold leading-tight text-aluminum-100">{title}</h3>
+        <h3 className="type-subheading">{title}</h3>
         <p className="text-sm text-aluminum-300">
           {company} · {location}
         </p>
-        <p className="text-xs font-semibold uppercase text-aluminum-400">{period}</p>
+        <p className="eyebrow">{period}</p>
       </div>
       {highlights && highlights.length > 0 && (
         <ul className="mt-6 list-disc space-y-3 pl-6 text-sm leading-relaxed text-aluminum-300 marker:text-ember-300">

--- a/src/components/ui/Hero.tsx
+++ b/src/components/ui/Hero.tsx
@@ -43,12 +43,12 @@ export function Hero({
 
           <div className="space-y-6 lg:col-span-3" data-animate="hero-copy">
             <span
-              className="inline-flex items-center rounded-full border border-ember-400/30 bg-ember-500/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.4em] text-ember-200 texture-noise"
+              className="inline-flex items-center rounded-full border border-ember-400/30 bg-ember-500/10 px-4 py-2 eyebrow text-ember-200 texture-noise"
               data-animate="hero-badge">
               {badge}
             </span>
 
-            <h1 className="text-4xl font-semibold text-aluminum-100 sm:text-5xl" data-animate="hero-heading">
+            <h1 className="type-display" data-animate="hero-heading">
               {heading}
             </h1>
 

--- a/src/components/ui/ProjectCard.tsx
+++ b/src/components/ui/ProjectCard.tsx
@@ -41,7 +41,7 @@ export function ProjectCard({ project }: ProjectCardProps) {
           </div>
         )}
         <div className="space-y-2">
-          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-aluminum-400">
+          <p className="eyebrow">
             {platform}
             {status ? ` · ${status}` : ''}
           </p>
@@ -59,7 +59,7 @@ export function ProjectCard({ project }: ProjectCardProps) {
               )}
             </p>
           )}
-          <h3 className="text-xl font-semibold leading-tight text-aluminum-100">{name}</h3>
+          <h3 className="type-subheading">{name}</h3>
           {audience && <p className="text-sm leading-relaxed text-aluminum-300">{audience}</p>}
         </div>
       </div>
@@ -68,7 +68,7 @@ export function ProjectCard({ project }: ProjectCardProps) {
 
       {technologies && technologies.length > 0 && (
         <div className="mt-6 space-y-3">
-          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-aluminum-400">Core technologies</p>
+          <p className="eyebrow">Core technologies</p>
           <ul className="flex flex-wrap gap-2">
             {technologies.map((tech) => (
               <Tag as="li" key={tech}>
@@ -81,7 +81,7 @@ export function ProjectCard({ project }: ProjectCardProps) {
 
       {features && features.length > 0 && (
         <div className="mt-6 space-y-3">
-          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-aluminum-400">Key features</p>
+          <p className="eyebrow">Key features</p>
           <ul className="list-disc space-y-2 pl-5 text-sm leading-relaxed text-aluminum-300 marker:text-ember-300">
             {features.map((feature) => (
               <li key={feature}>{feature}</li>

--- a/src/components/ui/ProjectsShowcase.tsx
+++ b/src/components/ui/ProjectsShowcase.tsx
@@ -96,12 +96,12 @@ export function ProjectsShowcase({ projects }: ProjectsShowcaseProps) {
       className="scroll-mt-32 flex min-h-screen flex-col justify-center border-b border-aluminum-500/20 bg-transparent">
       <div className="mx-auto w-full max-w-5xl px-6 py-16">
         <div className="max-w-3xl space-y-4" data-animate="section-heading">
-          <h2 className="text-3xl font-semibold text-aluminum-100">Projects</h2>
+          <h2 className="type-heading">Projects</h2>
         </div>
 
         <div className="mt-10 space-y-6" data-animate="section-heading">
           <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4">
-            <span className="text-xs font-semibold uppercase tracking-[0.3em] text-aluminum-400">Sort</span>
+            <span className="eyebrow">Sort</span>
             <div className="flex flex-wrap gap-2">
               {SORTS.map((s) => (
                 <button
@@ -117,7 +117,7 @@ export function ProjectsShowcase({ projects }: ProjectsShowcaseProps) {
           </div>
 
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
-            <span className="text-xs font-semibold uppercase tracking-[0.3em] text-aluminum-400">Filter</span>
+            <span className="eyebrow">Filter</span>
             <div className="flex flex-wrap gap-2">
               <button
                 type="button"

--- a/src/components/ui/SectionHeading.tsx
+++ b/src/components/ui/SectionHeading.tsx
@@ -9,7 +9,7 @@ interface SectionHeadingProps {
 export function SectionHeading({ title, intro }: SectionHeadingProps) {
   return (
     <div className="max-w-3xl space-y-4" data-animate="section-heading">
-      <h2 className="text-3xl font-semibold text-aluminum-100">{title}</h2>
+      <h2 className="type-heading">{title}</h2>
       {intro && <p className="text-lg text-aluminum-300">{intro}</p>}
     </div>
   );

--- a/src/components/ui/StarsBackground.stories.tsx
+++ b/src/components/ui/StarsBackground.stories.tsx
@@ -26,10 +26,10 @@ export const Default: Story = {
   args: {
     children: (
       <div className="relative flex min-h-[70vh] flex-col items-center justify-center gap-3 px-6 text-center">
-        <span className="inline-flex items-center rounded-full border border-ember-400/30 bg-ember-500/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.4em] text-ember-200">
+        <span className="inline-flex items-center rounded-full border border-ember-400/30 bg-ember-500/10 px-4 py-2 eyebrow text-ember-200">
           Stars background
         </span>
-        <h2 className="text-4xl font-semibold text-aluminum-100">Move your cursor</h2>
+        <h2 className="type-display">Move your cursor</h2>
         <p className="max-w-md text-aluminum-300">
           Three drifting layers with a spring-like pointer parallax. Pauses for reduced-motion users.
         </p>

--- a/src/components/ui/StatCard.tsx
+++ b/src/components/ui/StatCard.tsx
@@ -8,8 +8,8 @@ interface StatCardProps {
 export function StatCard({ label, value, detail }: StatCardProps) {
   return (
     <div className="surface-panel p-6" data-animate="hero-stat">
-      <p className="text-sm uppercase tracking-[0.3em] text-aluminum-400">{label}</p>
-      <p className="mt-3 text-2xl font-semibold text-aluminum-100">{value}</p>
+      <p className="eyebrow">{label}</p>
+      <p className="mt-3 text-2xl font-semibold tabular-nums text-aluminum-100">{value}</p>
       <p className="mt-2 text-sm text-aluminum-400">{detail}</p>
     </div>
   );

--- a/src/components/ui/SurfacePanel.stories.tsx
+++ b/src/components/ui/SurfacePanel.stories.tsx
@@ -14,7 +14,7 @@ export const Default: Story = {
     className: 'p-6 max-w-sm',
     children: (
       <>
-        <p className="text-sm uppercase tracking-[0.3em] text-aluminum-400">Surface panel</p>
+        <p className="eyebrow">Surface panel</p>
         <p className="mt-3 text-2xl font-semibold text-aluminum-100">Hover me</p>
         <p className="mt-2 text-sm text-aluminum-400">Ember ring and spotlight glow on hover.</p>
       </>

--- a/src/layouts/AppProjectLayout.astro
+++ b/src/layouts/AppProjectLayout.astro
@@ -69,13 +69,13 @@ const navLink =
           <div>
             {
               (platform || status) && (
-                <p class="text-xs font-semibold uppercase tracking-[0.3em] text-aluminum-400">
+                <p class="eyebrow">
                   {platform}
                   {status ? ` · ${status}` : ''}
                 </p>
               )
             }
-            <h1 class="mt-3 text-4xl font-semibold text-aluminum-100">{data.title}</h1>
+            <h1 class="mt-3 type-title">{data.title}</h1>
             {data.subtitle && <p class="mt-3 text-lg leading-relaxed text-aluminum-300">{data.subtitle}</p>}
             {audience && <p class="mt-3 max-w-[60ch] text-sm leading-relaxed text-aluminum-400">{audience}</p>}
             {
@@ -126,7 +126,7 @@ const navLink =
     {
       hasFeatures && (
         <section id="features" class="mx-auto max-w-5xl px-6 pb-16">
-          <h2 class="text-2xl font-semibold text-aluminum-100">Features</h2>
+          <h2 class="type-heading">Features</h2>
           <ul class="mt-6 grid gap-4 sm:grid-cols-2">
             {features.map((f) => (
               <li class="surface-panel p-5 text-sm leading-relaxed text-aluminum-300">{f}</li>
@@ -134,7 +134,7 @@ const navLink =
           </ul>
           {technologies.length > 0 && (
             <div class="mt-8">
-              <p class="text-xs font-semibold uppercase tracking-[0.3em] text-aluminum-400">Built with</p>
+              <p class="eyebrow">Built with</p>
               <ul class="mt-3 flex flex-wrap gap-2">
                 {technologies.map((t) => (
                   <li class="rounded-full border border-aluminum-500/25 bg-graphite-700/60 px-3 py-1 text-xs text-aluminum-300">

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -22,8 +22,8 @@ function fmtFull(d?: Date | string): string {
   <article class="bg-transparent py-16 text-aluminum-100">
     <div class="mx-auto max-w-3xl px-6">
       <header class="space-y-3">
-        {date && <p class="text-xs font-semibold uppercase text-aluminum-400">{fmtFull(date)}</p>}
-        <h1 class="text-3xl font-bold text-aluminum-100 md:text-4xl">{title}</h1>
+        {date && <p class="eyebrow">{fmtFull(date)}</p>}
+        <h1 class="type-title">{title}</h1>
         {description && <p class="text-lg text-aluminum-300">{description}</p>}
       </header>
       <div class="prose prose-invert mt-8 max-w-none">

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -44,10 +44,10 @@ const hasUpdates = (data.updates?.length ?? 0) > 0;
         >
         {
           data.type && (
-            <p class="mt-8 text-xs font-semibold uppercase tracking-[0.35em] text-aluminum-400">{data.type}</p>
+            <p class="mt-8 eyebrow">{data.type}</p>
           )
         }
-        <h1 class="mt-6 text-4xl font-semibold text-aluminum-100">{data.title}</h1>
+        <h1 class="mt-6 type-title">{data.title}</h1>
         {
           heroPair && (
             <figure class="mt-10">
@@ -118,7 +118,7 @@ const hasUpdates = (data.updates?.length ?? 0) > 0;
       data.links && (
         <div class="mx-auto max-w-5xl px-6 pb-20">
           <div class="surface-panel p-6">
-            <h2 class="text-lg font-semibold text-aluminum-100">Further reading</h2>
+            <h2 class="type-subheading">Further reading</h2>
             <ul class="mt-4 space-y-2 text-sm text-aluminum-300">
               {data.links.map((link) => (
                 <li>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -4,8 +4,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
 <BaseLayout title="Page not found">
   <section class="flex min-h-[70vh] flex-col items-center justify-center bg-charcoal-900 px-6 text-center">
-    <p class="text-sm font-semibold uppercase tracking-[0.4em] text-ember-200">404</p>
-    <h1 class="mt-6 text-4xl font-semibold text-aluminum-100">Page not found</h1>
+    <p class="eyebrow text-ember-200">404</p>
+    <h1 class="mt-6 type-title">Page not found</h1>
     <p class="mt-4 max-w-md text-lg text-aluminum-300">
       The page you're looking for doesn't exist or has moved.
     </p>

--- a/src/pages/style-guide.astro
+++ b/src/pages/style-guide.astro
@@ -6,16 +6,16 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   <section class="bg-charcoal-900 py-16 text-aluminum-100">
     <div class="mx-auto flex max-w-5xl flex-col gap-12 px-6">
       <header class="space-y-4">
-        <p class="text-sm font-semibold uppercase tracking-[0.3em] text-aluminum-400">Foundations</p>
-        <h1 class="text-3xl font-bold text-aluminum-100 md:text-4xl">Interface style guide</h1>
+        <p class="eyebrow">Foundations</p>
+        <h1 class="type-title">Interface style guide</h1>
         <p class="text-lg text-aluminum-300">
-          A lightweight reference for the site's evolved visual language. Charcoal neutrals, a burnt orange accent, and a
-          subtle anodised aluminium texture reserved for highlights shape the refreshed interface.
+          A lightweight reference for the site's visual language. Charcoal neutrals, a burnt-orange ember accent, a
+          subtle anodised-aluminium texture on highlights, and a three-family type system shape the interface.
         </p>
       </header>
 
       <section class="space-y-6">
-        <h2 class="text-2xl font-semibold text-aluminum-100">Color palette</h2>
+        <h2 class="type-heading">Colour palette</h2>
         <div class="grid gap-6 md:grid-cols-3">
           <div class="rounded-xl border border-aluminum-500/25 bg-graphite-700/70 p-6">
             <div class="h-16 w-full rounded-lg bg-charcoal-900"></div>
@@ -33,29 +33,57 @@ import BaseLayout from '../layouts/BaseLayout.astro';
             <p class="text-sm text-aluminum-300">Ember 400</p>
           </div>
         </div>
-        <p class="text-sm text-aluminum-300">
-          Charcoal and graphite neutrals keep focus on content, while the ember accent provides warmth for interactive
-          states.
-        </p>
       </section>
 
       <section class="space-y-6">
-        <h2 class="text-2xl font-semibold text-aluminum-100">Typography</h2>
-        <div class="space-y-3 rounded-xl border border-aluminum-500/25 bg-graphite-700/70 p-6">
-          <h3 class="text-3xl font-bold text-aluminum-100">Heading example</h3>
-          <p class="text-lg text-aluminum-300">
-            Body copy remains in the system sans-serif stack for clarity. Generous spacing reinforces the premium
-            industrial tone introduced by the new palette.
-          </p>
-          <p class="text-sm uppercase tracking-[0.3em] text-aluminum-400">Supporting label text</p>
+        <h2 class="type-heading">Typography</h2>
+        <p class="text-lg text-aluminum-300">
+          <strong class="text-aluminum-100">Fraunces</strong> (display serif) is reserved for h1-level titles;
+          <strong class="text-aluminum-100">Hanken Grotesk</strong> carries sections, cards and body;
+          <strong class="text-aluminum-100">JetBrains Mono</strong> handles eyebrows, labels and code. Apply the
+          <code class="text-sm text-ember-200">.type-*</code> and <code class="text-sm text-ember-200">.eyebrow</code>
+          roles by intent, not the raw heading level.
+        </p>
+        <div class="space-y-8 rounded-xl border border-aluminum-500/25 bg-graphite-700/70 p-8">
+          <div class="space-y-1">
+            <p class="eyebrow text-aluminum-500">.type-display · Fraunces · hero</p>
+            <p class="type-display">Hello, I'm Liam Day</p>
+          </div>
+          <div class="space-y-1">
+            <p class="eyebrow text-aluminum-500">.type-title · Fraunces · page h1</p>
+            <p class="type-title">Project title</p>
+          </div>
+          <div class="space-y-1">
+            <p class="eyebrow text-aluminum-500">.type-heading · Hanken · section h2</p>
+            <p class="type-heading">Section heading</p>
+          </div>
+          <div class="space-y-1">
+            <p class="eyebrow text-aluminum-500">.type-subheading · Hanken · card h3</p>
+            <p class="type-subheading">Card title / sub-heading</p>
+          </div>
+          <div class="space-y-1">
+            <p class="eyebrow text-aluminum-500">.eyebrow · JetBrains Mono · labels</p>
+            <p class="eyebrow">Product manager · Winchester</p>
+          </div>
+          <div class="space-y-1">
+            <p class="eyebrow text-aluminum-500">body · Hanken Grotesk</p>
+            <p class="max-w-2xl text-lg text-aluminum-300">
+              Body copy is set in Hanken Grotesk — a humanist grotesque tuned for long-form readability, paired with the
+              serif so headings carry the voice and paragraphs stay quiet.
+            </p>
+          </div>
+          <div class="space-y-1">
+            <p class="eyebrow text-aluminum-500">mono · JetBrains Mono</p>
+            <p><code class="text-sm text-aluminum-200">const clearance = "DV"; // labels, code, metadata</code></p>
+          </div>
         </div>
       </section>
 
       <section class="space-y-6">
-        <h2 class="text-2xl font-semibold text-aluminum-100">Components</h2>
+        <h2 class="type-heading">Components</h2>
         <div class="grid gap-6 md:grid-cols-2">
           <div class="rounded-xl border border-aluminum-500/25 bg-graphite-700/70 p-6">
-            <p class="text-sm font-semibold text-aluminum-100">Buttons</p>
+            <p class="eyebrow">Buttons</p>
             <div class="mt-4 flex flex-wrap gap-3">
               <a
                 class="inline-flex items-center justify-center rounded-full border border-aluminum-500/40 px-5 py-2 text-sm font-semibold text-aluminum-200 transition hover:border-ember-400/40 hover:bg-ember-500/10"
@@ -68,9 +96,9 @@ import BaseLayout from '../layouts/BaseLayout.astro';
             </div>
           </div>
           <div class="rounded-xl border border-aluminum-500/25 bg-graphite-700/70 p-6">
-            <p class="text-sm font-semibold text-aluminum-100">Cards</p>
+            <p class="eyebrow">Cards</p>
             <div class="mt-4 space-y-3 surface-panel p-4 shadow-none">
-              <h3 class="text-lg font-semibold text-aluminum-100">Simple card</h3>
+              <h3 class="type-subheading">Simple card</h3>
               <p class="text-sm text-aluminum-300">
                 Surface treatments rely on softened graphite borders, while ember accents carry the anodised texture for
                 contrast.

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -95,11 +95,10 @@
     font-family: var(--ff-body, ui-sans-serif, system-ui, sans-serif);
   }
 
-  /* Headings carry the editorial serif; weight utilities (font-semibold etc.)
-     still win from the utilities layer, so only the family is set here. */
-  h1,
-  h2,
-  h3 {
+  /* Only h1-level titles wear the display serif (Fraunces). Section (h2) and
+     sub (h3) headings inherit the body grotesque. Visual size/weight lives in
+     the .type-* role classes below — never keyed off the raw element. */
+  h1 {
     font-family: var(--ff-display, Georgia, Cambria, serif);
   }
 
@@ -121,6 +120,33 @@
 }
 
 @layer components {
+  /* ──────────────────────────────────────────────────────────────────────
+     Type roles — single source of truth for heading & label treatment.
+     Applied by *role*, not by element level, so semantic h-levels stay
+     correct while visual weight is consistent. Serif (Fraunces) is reserved
+     for title roles; sections/cards use the body grotesque; labels use mono.
+     These live in the components layer, so a one-off utility can still
+     override any single property on an element.
+     ────────────────────────────────────────────────────────────────────── */
+  .type-display {
+    font-family: var(--ff-display, Georgia, serif);
+    @apply text-4xl font-semibold tracking-[-0.02em] text-aluminum-100 sm:text-5xl;
+  }
+  .type-title {
+    font-family: var(--ff-display, Georgia, serif);
+    @apply text-4xl font-semibold tracking-[-0.01em] text-aluminum-100;
+  }
+  .type-heading {
+    @apply text-3xl font-semibold tracking-[-0.01em] text-aluminum-100;
+  }
+  .type-subheading {
+    @apply text-xl font-semibold leading-tight text-aluminum-100;
+  }
+  .eyebrow {
+    font-family: var(--ff-mono, ui-monospace, monospace);
+    @apply text-xs font-medium uppercase tracking-[0.2em] text-aluminum-400;
+  }
+
   .surface-panel {
     @apply rounded-2xl border border-aluminum-500/20 bg-graphite-700/80 shadow-glow backdrop-blur;
     position: relative;


### PR DESCRIPTION
## Summary
- Replace element-level heading styling with **intent-based type roles** (single source of truth in `global.css`): `.type-display`/`.type-title` (Fraunces, h1-level titles), `.type-heading`/`.type-subheading` (Hanken, sections + cards), `.eyebrow` (JetBrains Mono, uppercase, unified 0.2em tracking).
- **Serif reserved for h1 titles only**; the ~20 drifting eyebrow labels (4 tracking values, 3 sizes, all sans) converge to one mono-uppercase treatment.
- Applied across every component/layout/page; the `/style-guide/` page is rewritten as a living type reference.
- Disable the dev-only Astro toolbar (never ships to production; keeps the preview clean).

Advances #140. Element levels stay semantically correct — treatment is driven by role, not tag.

## Test plan
- [x] Computed styles verified per role: hero h1 → Fraunces, section h2 → Hanken (not serif), card h3 → Hanken, eyebrow → JetBrains Mono uppercase 0.2em
- [x] No ad-hoc heading/label utilities remain (only intentional: `Button` pill, `StatCard` value)
- [x] Dev server compiles with no errors; `astro-dev-toolbar` absent from DOM
- [ ] Pages deploy succeeds on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)