### PR TITLE
fix: recreate corrupt HomeOS hero SVGs

### DIFF
--- a/public/assets/images/projects/homeos-hero-light.svg
+++ b/public/assets/images/projects/homeos-hero-light.svg
@@ -1,1 +1,70 @@
-²ø1šYì
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 800" role="img" aria-labelledby="ho-hero-title-l ho-hero-desc-l" preserveAspectRatio="xMidYMid slice">
+  <title id="ho-hero-title-l">HomeOS</title>
+  <desc id="ho-hero-desc-l">A central ember-orange house core on a warm-light field, surrounded by seven room nodes joined to it by quiet spokes, with a warm sun glow.</desc>
+
+  <defs>
+    <radialGradient id="ho-hero-bg-l" cx="50%" cy="50%" r="78%">
+      <stop offset="0%" stop-color="#faf6f0"/>
+      <stop offset="58%" stop-color="#f3ede3"/>
+      <stop offset="100%" stop-color="#ece2d2"/>
+    </radialGradient>
+    <radialGradient id="ho-hero-glow-l" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#cc785c" stop-opacity="0.20"/>
+      <stop offset="60%" stop-color="#cc785c" stop-opacity="0.06"/>
+      <stop offset="100%" stop-color="#cc785c" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="ho-hero-sun-l" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#e08a63" stop-opacity="0.16"/>
+      <stop offset="55%" stop-color="#e08a63" stop-opacity="0.05"/>
+      <stop offset="100%" stop-color="#e08a63" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="ho-hero-house-l" cx="38%" cy="28%" r="80%">
+      <stop offset="0%" stop-color="#f7d2b2"/>
+      <stop offset="50%" stop-color="#e08a63"/>
+      <stop offset="100%" stop-color="#a85c44"/>
+    </radialGradient>
+  </defs>
+
+  <!-- Warm light field -->
+  <rect width="1600" height="800" fill="url(#ho-hero-bg-l)"/>
+
+  <!-- Warm sun glow -->
+  <circle cx="1260" cy="170" r="300" fill="url(#ho-hero-sun-l)"/>
+  <circle cx="800" cy="405" r="380" fill="url(#ho-hero-glow-l)"/>
+
+  <!-- Spokes from the house to the rooms -->
+  <g stroke="#b5613f" stroke-opacity="0.45" stroke-width="2" fill="none" stroke-linecap="round">
+    <line x1="800" y1="275" x2="800" y2="200"/>
+    <line x1="901.6" y1="323.9" x2="960.3" y2="277.2"/>
+    <line x1="926.7" y1="433.9" x2="999.9" y2="450.6"/>
+    <line x1="856.4" y1="522.1" x2="889.0" y2="589.7"/>
+    <line x1="743.6" y1="522.1" x2="711.0" y2="589.7"/>
+    <line x1="673.3" y1="433.9" x2="600.1" y2="450.6"/>
+    <line x1="698.4" y1="323.9" x2="639.7" y2="277.2"/>
+  </g>
+
+  <!-- Seven room nodes -->
+  <g fill="#ffffff" stroke="#3d3929" stroke-width="1.5">
+    <circle cx="800" cy="175" r="9"/>
+    <circle cx="979.8" cy="261.6" r="9"/>
+    <circle cx="1024.2" cy="456.2" r="9"/>
+    <circle cx="899.8" cy="612.2" r="9"/>
+    <circle cx="700.2" cy="612.2" r="9"/>
+    <circle cx="575.8" cy="456.2" r="9"/>
+    <circle cx="620.2" cy="261.6" r="9"/>
+  </g>
+
+  <!-- The house core -->
+  <circle cx="800" cy="415" r="118" fill="#cc785c" opacity="0.12"/>
+  <path d="M725 390 L800 330 L875 390 L875 480 L725 480 Z" fill="url(#ho-hero-house-l)"/>
+  <path d="M743 375.6 L800 330 L857 375.6" fill="none" stroke="#fbe7d6" stroke-opacity="0.8" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect x="782" y="428" width="36" height="52" rx="3" fill="#7a3f2e" fill-opacity="0.45"/>
+
+  <!-- Sparks -->
+  <g fill="#d98a63">
+    <circle cx="712" cy="292" r="2.6" opacity="0.8"/>
+    <circle cx="902" cy="286" r="2" opacity="0.65"/>
+    <circle cx="668" cy="540" r="1.8" opacity="0.55"/>
+    <circle cx="948" cy="528" r="2.2" opacity="0.7"/>
+  </g>
+</svg>

--- a/public/assets/images/projects/homeos-hero.svg
+++ b/public/assets/images/projects/homeos-hero.svg
@@ -1,1 +1,70 @@
-²ø1šYì
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 800" role="img" aria-labelledby="ho-hero-title ho-hero-desc" preserveAspectRatio="xMidYMid slice">
+  <title id="ho-hero-title">HomeOS</title>
+  <desc id="ho-hero-desc">A central ember-orange house core on a warm-dark field, surrounded by seven room nodes joined to it by quiet spokes, with a warm sun glow.</desc>
+
+  <defs>
+    <radialGradient id="ho-hero-bg" cx="50%" cy="50%" r="78%">
+      <stop offset="0%" stop-color="#33251f"/>
+      <stop offset="58%" stop-color="#231b17"/>
+      <stop offset="100%" stop-color="#1a1410"/>
+    </radialGradient>
+    <radialGradient id="ho-hero-glow" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#cc785c" stop-opacity="0.38"/>
+      <stop offset="42%" stop-color="#cc785c" stop-opacity="0.11"/>
+      <stop offset="100%" stop-color="#cc785c" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="ho-hero-sun" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#f3b184" stop-opacity="0.22"/>
+      <stop offset="55%" stop-color="#f3b184" stop-opacity="0.07"/>
+      <stop offset="100%" stop-color="#f3b184" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="ho-hero-house" cx="38%" cy="28%" r="80%">
+      <stop offset="0%" stop-color="#eda988"/>
+      <stop offset="55%" stop-color="#cc785c"/>
+      <stop offset="100%" stop-color="#a85c44"/>
+    </radialGradient>
+  </defs>
+
+  <!-- Warm dark field -->
+  <rect width="1600" height="800" fill="url(#ho-hero-bg)"/>
+
+  <!-- Warm sun glow -->
+  <circle cx="1260" cy="170" r="300" fill="url(#ho-hero-sun)"/>
+  <circle cx="800" cy="405" r="380" fill="url(#ho-hero-glow)"/>
+
+  <!-- Spokes from the house to the rooms -->
+  <g stroke="#cc785c" stroke-opacity="0.45" stroke-width="2" fill="none" stroke-linecap="round">
+    <line x1="800" y1="275" x2="800" y2="200"/>
+    <line x1="901.6" y1="323.9" x2="960.3" y2="277.2"/>
+    <line x1="926.7" y1="433.9" x2="999.9" y2="450.6"/>
+    <line x1="856.4" y1="522.1" x2="889.0" y2="589.7"/>
+    <line x1="743.6" y1="522.1" x2="711.0" y2="589.7"/>
+    <line x1="673.3" y1="433.9" x2="600.1" y2="450.6"/>
+    <line x1="698.4" y1="323.9" x2="639.7" y2="277.2"/>
+  </g>
+
+  <!-- Seven room nodes -->
+  <g fill="#f3ebde">
+    <circle cx="800" cy="175" r="9"/>
+    <circle cx="979.8" cy="261.6" r="9"/>
+    <circle cx="1024.2" cy="456.2" r="9"/>
+    <circle cx="899.8" cy="612.2" r="9"/>
+    <circle cx="700.2" cy="612.2" r="9"/>
+    <circle cx="575.8" cy="456.2" r="9"/>
+    <circle cx="620.2" cy="261.6" r="9"/>
+  </g>
+
+  <!-- The house core -->
+  <circle cx="800" cy="415" r="118" fill="#cc785c" opacity="0.16"/>
+  <path d="M725 390 L800 330 L875 390 L875 480 L725 480 Z" fill="url(#ho-hero-house)"/>
+  <path d="M743 375.6 L800 330 L857 375.6" fill="none" stroke="#fdeee0" stroke-opacity="0.5" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect x="782" y="428" width="36" height="52" rx="3" fill="#7a3f2e" fill-opacity="0.55"/>
+
+  <!-- Sparks -->
+  <g fill="#f9dcc3">
+    <circle cx="712" cy="292" r="2.6" opacity="0.85"/>
+    <circle cx="902" cy="286" r="2" opacity="0.7"/>
+    <circle cx="668" cy="540" r="1.8" opacity="0.6"/>
+    <circle cx="948" cy="528" r="2.2" opacity="0.75"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

`homeos-hero.svg` and `homeos-hero-light.svg` have been corrupt (6 bytes of non-SVG garbage) since they were first committed in a3496c2 — the HomeOS case study hero has never rendered. No valid version exists in git history, so both are recreated rather than restored.

## Approach

- Spec taken from the existing `hero_image_alt` in `homeos.mdx`: *"a central ember-orange house core surrounded by seven room nodes, with a warm sun glow"*
- House-and-door geometry reused from the intact `homeos-icon.svg`; field, glow, and palette follow the 1600×800 dark/light hero grammar shared by the other case studies
- Seven room nodes at even spacing joined to the house by quiet ember spokes; warm sun glow upper right

## Verification

- Both SVGs rasterise cleanly via rsvg-convert
- `/projects/homeos/` verified in the dev server in dark and light themes — hero renders in both

🤖 Generated with [Claude Code](https://claude.com/claude-code)