### PR TITLE
feat(cv): three-tier heading hierarchy for military experience entries

### DIFF
--- a/src/components/DefenceConsole.tsx
+++ b/src/components/DefenceConsole.tsx
@@ -37,6 +37,7 @@ export interface GeoPoint {
 
 export interface ConsoleRole {
   title: string;
+  appointment?: string;
   company: string;
   location: string;
   period: string;
@@ -1242,7 +1243,12 @@ export default function DefenceConsole(props: DefenceConsoleProps) {
                         02.{i + 1} | {role.period.toUpperCase()}
                       </p>
                       <h3 className="t-heading mt-4 text-2xl md:text-3xl">{role.title}</h3>
-                      <p className="mt-2 text-aluminum-300">
+                      {role.appointment && (
+                        <p className="mt-1 text-lg font-medium text-aluminum-200 md:text-xl">
+                          {role.appointment}
+                        </p>
+                      )}
+                      <p className="mt-3 text-aluminum-300">
                         {role.company}
                         <span className="mx-2 text-aluminum-400">·</span>
                         {role.location}

--- a/src/components/ui/ExperienceCard.stories.tsx
+++ b/src/components/ui/ExperienceCard.stories.tsx
@@ -21,3 +21,17 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+
+export const MilitaryRole: Story = {
+  args: {
+    title: 'Technical Coordinator',
+    appointment: 'Regimental Signals Officer',
+    company: "British Army - 1st Bn Duke of Lancaster's Regiment",
+    location: 'Chester, UK',
+    period: 'Jul 2018 – Jul 2020',
+    highlights: [
+      'Coordinated secure communications infrastructure across a regiment of 500+ personnel.',
+      'Increased trained communication specialists from 2 to 8 per 30-person team.',
+    ],
+  },
+};

--- a/src/components/ui/ExperienceCard.tsx
+++ b/src/components/ui/ExperienceCard.tsx
@@ -1,5 +1,7 @@
 interface ExperienceCardProps {
   title: string;
+  /** Military appointment name, rendered as a second heading tier under the functional title. */
+  appointment?: string;
   company: string;
   location: string;
   period: string;
@@ -7,13 +9,14 @@ interface ExperienceCardProps {
 }
 
 /** A single role in the experience timeline. */
-export function ExperienceCard({ title, company, location, period, highlights }: ExperienceCardProps) {
+export function ExperienceCard({ title, appointment, company, location, period, highlights }: ExperienceCardProps) {
   return (
     <article
       className="surface-panel p-6 shadow-[0_20px_45px_-30px_rgba(0,0,0,0.9)] lg:p-8"
       data-animate="experience-card">
       <div className="space-y-1">
         <h3 className="type-subheading">{title}</h3>
+        {appointment && <p className="text-base font-medium text-aluminum-200">{appointment}</p>}
         <p className="text-sm text-aluminum-300">
           {company} · {location}
         </p>

--- a/src/data/cv.ts
+++ b/src/data/cv.ts
@@ -11,6 +11,8 @@ export interface Competency {
 }
 export interface Role {
   title: string;
+  /** Military appointment name, rendered as a second heading tier under the functional title. */
+  appointment?: string;
   company: string;
   location: string;
   period: string;

--- a/src/data/cv.yml
+++ b/src/data/cv.yml
@@ -64,7 +64,8 @@ employment:
       - Provides second-line technical support for B2C users, maintaining direct contact with consumer pain points and reducing inbound support volume by 19% year-on-year.
 
   - title: Product Manager & Programme Manager
-    company: British Army — Combat CIS School
+    appointment: SO3 Dismounted Close Combat
+    company: British Army - Combat CIS School
     location: Bovington, Dorset, UK
     period: Jul 2020 – Sep 2023
     highlights:
@@ -74,8 +75,9 @@ employment:
       - Led a cross-functional team of 12 and a wider community of 32 senior NCOs, running weekly stand-ups, sprint reviews and retrospectives aligned to agile principles in a regulated, security-sensitive environment.
       - Produced business cases, roadmaps and risk registers to secure Director-level investment approval; managed programme budget and resource allocation throughout delivery.
 
-  - title: Regimental Signals Officer (Technical Coordinator)
-    company: British Army — 1st Bn Duke of Lancaster's Regiment
+  - title: Technical Coordinator
+    appointment: Regimental Signals Officer
+    company: British Army - 1st Bn Duke of Lancaster's Regiment
     location: Chester, UK
     period: Jul 2018 – Jul 2020
     highlights:
@@ -85,7 +87,8 @@ employment:
       - Maintained 100% compliance with cryptographic material security protocols, achieving an incident-free reporting period across both years of responsibility.
 
   - title: Operations Officer
-    company: British Army — 1st Bn Duke of Lancaster's Regiment
+    appointment: Company Second-in-Command
+    company: British Army - 1st Bn Duke of Lancaster's Regiment
     location: Cyprus
     period: Jul 2016 – Jul 2018
     highlights:
@@ -93,7 +96,8 @@ employment:
       - Managed and maintained full accountability for £3M of serialised equipment across complex international training deployments, achieving 100% operational readiness throughout.
 
   - title: Team Leader
-    company: British Army — 1st Bn Duke of Lancaster's Regiment
+    appointment: Platoon Commander
+    company: British Army - 1st Bn Duke of Lancaster's Regiment
     location: Cyprus
     period: Jul 2014 – Jul 2016
     highlights:


### PR DESCRIPTION
## Summary
- Experience entries now lead with the functional title, with the military appointment as a new second heading tier above the org · location line (e.g. Technical Coordinator / Regimental Signals Officer / British Army - 1st Bn Duke of Lancaster's Regiment · Chester, UK)
- All four Army roles carry an `appointment:` (SO3 Dismounted Close Combat, Regimental Signals Officer, Company Second-in-Command, Platoon Commander); civilian roles stay two-tier
- Em dashes in "British Army" company strings swapped for hyphens; ExperienceCard (Storybook) mirrors the structure with a new MilitaryRole story

## Test plan
- [x] Dev server: all five roles render the correct tiers (verified via DOM + computed styles: 30px/20px/16px, aluminum-100/200/300)
- [x] `npm run build` passes (36 pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)