### PR TITLE
content(peaking): backfill the v1.9, v1.10 and v1.11 release entries

### DIFF
--- a/src/content/projects/peaking.mdx
+++ b/src/content/projects/peaking.mdx
@@ -215,6 +215,48 @@ updates:
       partners have been. And peak and collection detail screens are now fully
       customisable — sections can be reordered or hidden entirely to put the
       information you care about most first.
+  - date: 2026-07-22
+    version: v1.9
+    id: v1-9
+    title: v1.9 — Connections that repair themselves, and lighter Strava imports
+    summary: Stalled friend connections surface with a one-tap fix, and route detail loads on demand.
+    content: |
+      Friend connections that had quietly gone stale now surface in a "needs
+      attention" list with a single action to reconnect or repair them, instead
+      of failing silently and leaving both people guessing. Strava imports moved
+      from fetching every route up front to pulling the detail only when a route
+      is opened, which makes a large history far quicker to bring in. Long lists
+      gained a consistent "view all" affordance rather than truncating without
+      saying so, and a searchable FAQ landed alongside a settings search that
+      finds options by what you are trying to do rather than by what the setting
+      happens to be called.
+  - date: 2026-07-23
+    version: v1.10
+    id: v1-10
+    title: v1.10 — Aerial 3D on the main map, and the trail catalogue doubles
+    summary: A cinematic orbit of any summit, and roughly twice as many trails to follow.
+    content: |
+      Aerial 3D moved out of a small inset and onto the main map: choose a peak
+      and the camera flies in and orbits the summit over terrain and satellite
+      imagery until you touch the screen to take over. The trail catalogue
+      roughly doubled — including a corrected set of Scotland's Great Trails —
+      and trails gained a tagging model, so they can be browsed by the kind of
+      walk they are rather than only by name. Peak detail also folded weather
+      into the same reorderable section layout as everything else, so it can be
+      moved or hidden like any other section.
+  - date: 2026-07-24
+    version: v1.11
+    id: v1-11
+    title: v1.11 — Image-forward browsing
+    summary: A cards view across every content type, with photography leading.
+    content: |
+      Peaks, trails and achievements all gained an image-forward cards view, so
+      browsing leads with photography instead of a column of names. Favourite
+      and pin became one consistent gesture everywhere — the same swipe, the
+      same long-press menu, the same badges — across peaks, routes, summits,
+      collections, trails and photos, replacing several near-identical
+      implementations that had drifted apart. Card images are now fetched ahead
+      of being scrolled to, so a grid fills in rather than resolving under you.
 ---
 Peaking is a mountain companion for hillwalkers and mountaineers. It maps the peaks
 around you, confirms a summit from the route you actually walked, and tracks your


### PR DESCRIPTION
The Peaking project page's `updates:` timeline stops at **v1.8 (2026-07-10)** — but three more versions shipped externally after it and were never added:

| | tag date |
|---|---|
| v1.9.0 | 22 Jul 2026 |
| v1.10.0 | 23 Jul 2026 |
| v1.11.0 | 24 Jul 2026 |

Each entry is dated to its own tag and written in the established house style — benefit-led, no version numbers in the prose, no internal component names — matching the v1.7/v1.8 entries above them.

## Where the content came from

Each tag's actual commit range, not memory:

- **v1.9** — friends "needs attention" with reconnect/repair, Strava moving from eager bulk fetch to lazy per-route detail, the shared "view all" truncation affordance, and the FAQ + outcome-based settings search.
- **v1.10** — Aerial 3D promoted from an inset to the main map, the trail catalogue roughly doubling (46 → 91) with multi-axis tagging and a corrected set of Scotland's Great Trails, and weather folding into the reorderable peak-detail section layout.
- **v1.11** — image-forward cards across peaks/trails/achievements, the shared favourite/pin affordances replacing several drifted implementations, and card thumbnail prefetch.

## Deliberately not included

**v1.12.** It hasn't shipped — it's mid-QA on an internal beta. Its entry goes in when the external tag is cut, not before.

## Verified

`npm run build` passes and all three entries render in `dist/projects/peaking/index.html`.

Note: the build fails on a clean checkout until `npm install` runs — `topojson-client` is declared in `package.json` but was missing from my local `node_modules`. That's a stale local environment, not a repo defect (CI runs `npm ci`), and it reproduces on `main` unchanged. `package-lock.json` left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)