### PR TITLE
content(cv): Oxford Dynamics role, and make the hybrid globe link data-driven

### DIFF
--- a/src/components/DefenceConsole.tsx
+++ b/src/components/DefenceConsole.tsx
@@ -43,6 +43,9 @@ export interface ConsoleRole {
   period: string;
   highlights?: string[];
   geo: GeoPoint;
+  /** Hybrid/remote posting — drawn with an animated link back to home, and
+      framed so both ends of that link sit in view. */
+  hybrid?: boolean;
 }
 
 export interface ConsoleQualification {
@@ -102,10 +105,28 @@ interface GlobeState {
   focus: Focus;
 }
 
-/** Per-role framing: role 0 frames home↔posting together (both in view);
-    Mediterranean postings sit wider; UK postings tighter. */
-function roleFraming(role: ConsoleRole, index: number, home: GeoPoint) {
-  if (index === 0) {
+/** Not a career site. London anchors the domestic hybrid frame, where the
+    home↔posting pair alone spans barely half a degree. */
+const CONTEXT_LONDON = { lat: 51.5074, lng: -0.1278 };
+
+/** Per-role framing: hybrid postings frame home↔posting together (both ends of
+    the link in view); Mediterranean postings sit wider; UK postings tighter. */
+function roleFraming(role: ConsoleRole, home: GeoPoint) {
+  if (role.hybrid) {
+    const domestic =
+      Math.abs(role.geo.lat - home.lat) < 3 && Math.abs(role.geo.lng - home.lng) < 3;
+    if (domestic) {
+      // Home and posting sit half a degree apart, so the link only reads at
+      // county scale. Frame the home–posting–London triangle: London is there
+      // purely so the coast and estuary give the eye something to hold at a
+      // zoom where national outlines have left the frame.
+      const pts = [home, role.geo, CONTEXT_LONDON];
+      return {
+        lat: pts.reduce((sum, p) => sum + p.lat, 0) / pts.length,
+        lng: pts.reduce((sum, p) => sum + p.lng, 0) / pts.length,
+        camZ: 5.6,
+      };
+    }
     return {
       lat: (role.geo.lat + home.lat) / 2,
       lng: (role.geo.lng + home.lng) / 2,
@@ -255,8 +276,10 @@ const CareerPath = ({
   );
 };
 
-/** Role-01 remote-work link: an animated dashed arc between the posting and
-    home — marching dashes illustrate the recurring movement between the two. */
+/** Hybrid-posting link: an animated dashed arc between the posting and home —
+    marching dashes illustrate the recurring movement between the two. Lift,
+    dash pitch and march speed all scale with the hop, so a cross-continent
+    link and a county-scale one read identically at their own zoom levels. */
 const RemoteLink = ({
   from,
   to,
@@ -274,18 +297,25 @@ const RemoteLink = ({
 }) => {
   const lineRef = useRef<Line2>(null);
 
-  const points = useMemo(
-    () =>
-      greatCircleArcPoints(from, to, RADIUS * MARKER_ALTITUDE, 0.1).map(
-        (p) => [p.x, p.y, p.z] as [number, number, number],
-      ),
-    [from, to],
-  );
+  const { points, arcLength } = useMemo(() => {
+    const separation = latLongToVector3(from.lat, from.lng, 1).angleTo(
+      latLongToVector3(to.lat, to.lng, 1),
+    );
+    // The ballistic profile carries a floor that keeps short hops visible at
+    // continental zoom; on a domestic hop that floor is taller than the arc is
+    // long, so cap the lift at the separation itself.
+    const arc = greatCircleArcPoints(from, to, RADIUS * MARKER_ALTITUDE, Math.min(0.1, separation));
+    return {
+      points: arc.map((p) => [p.x, p.y, p.z] as [number, number, number]),
+      arcLength: separation * RADIUS,
+    };
+  }, [from, to]);
 
   useFrame((_, delta) => {
     const mat = lineRef.current?.material as { dashOffset?: number } | undefined;
     if (active && !reducedMotion && !muted && mat && typeof mat.dashOffset === 'number') {
-      mat.dashOffset -= delta * 0.4; // dashes flow from home toward the posting
+      // Flows from home toward the posting, at ~2 dash cycles/sec whatever the span.
+      mat.dashOffset -= delta * arcLength * 0.63;
     }
   });
 
@@ -302,8 +332,8 @@ const RemoteLink = ({
       color={color}
       lineWidth={1.6}
       dashed
-      dashSize={0.12}
-      gapSize={0.08}
+      dashSize={arcLength / 5}
+      gapSize={arcLength / 7.5}
       transparent
       opacity={0}
       depthWrite={false}
@@ -610,11 +640,14 @@ const Scene = ({
     return [...seen.values()];
   }, [roles]);
 
-  const markerScale = Math.min(1, Math.max(0.3, (state.camZ - RADIUS) / 5));
+  // Counter-scales markers against zoom. The floor has to clear the domestic
+  // hybrid frame (camZ 5.6): at anything above ~0.15 the two pins and their
+  // pulse rings merge into one blob at half a degree apart.
+  const markerScale = Math.min(1, Math.max(0.12, (state.camZ - RADIUS) / 5));
   const { focus } = state;
   const activeRole = typeof focus === 'number' ? focus : null;
-  // Role 0 is the remote posting: its focus lights BOTH ends of the link.
-  const homeActive = focus === 'home' || focus === 0;
+  // A hybrid posting's focus lights BOTH ends of its link.
+  const homeActive = focus === 'home' || (activeRole !== null && Boolean(roles[activeRole]?.hybrid));
   // Mobile: content sits over the globe everywhere, so accent elements
   // soften and pulses/labels stop — backdrop, never foreground.
   const muted = !isDesktop;
@@ -635,14 +668,19 @@ const Scene = ({
         {/* Geography layer — markers and arcs exist only in map mode */}
         <group visible={state.mode === 'map'}>
           <CareerPath color={accentCss} stations={stations} emphasised={activeRole !== null} muted={muted} />
-          <RemoteLink
-            from={homeGeo}
-            to={roles[0].geo}
-            color={accentCss}
-            active={focus === 0}
-            reducedMotion={reducedMotion}
-            muted={muted}
-          />
+          {roles.map((role, i) =>
+            role.hybrid ? (
+              <RemoteLink
+                key={role.geo.label}
+                from={homeGeo}
+                to={role.geo}
+                color={accentCss}
+                active={focus === i}
+                reducedMotion={reducedMotion}
+                muted={muted}
+              />
+            ) : null,
+          )}
           {sites.map(({ geo, roleIndices }) => {
             const pos = latLongToVector3(geo.lat, geo.lng, RADIUS).multiplyScalar(MARKER_ALTITUDE);
             const isActive = activeRole !== null && roleIndices.includes(activeRole);
@@ -1067,7 +1105,7 @@ export default function DefenceConsole(props: DefenceConsoleProps) {
       // creation order, and the section state must win those collisions.
       gsap.utils.toArray<HTMLElement>('[data-role-index]').forEach((el) => {
         const i = Number(el.dataset.roleIndex);
-        const framing = roleFraming(roles[i], i, homeGeo);
+        const framing = roleFraming(roles[i], homeGeo);
         const state: Partial<GlobeState> = {
           // Decimalised sub-clause: the roles are clauses 02.1 … 02.5 of /02.
           designation: `SEC /02.${i + 1} — EXPERIENCE`,

--- a/src/content/projects/outdooractive-mobile-qa.mdx
+++ b/src/content/projects/outdooractive-mobile-qa.mdx
@@ -3,7 +3,7 @@ title: Outdooractive Mobile Release Operations
 image: /assets/images/projects/outdooractive-mobile-qa-og-card.png
 summary: Strengthening quality loops across Outdooractive’s iOS, Android, and web apps to deliver more reliable experiences for outdoor enthusiasts.
 role: Technical Product Specialist
-year: 2023 – Present
+year: 2023 – 2026
 client: Outdooractive
 order: 1
 type: Case study

--- a/src/data/cv.yml
+++ b/src/data/cv.yml
@@ -52,10 +52,15 @@ competencies:
     description: Translate between technical specialists and non-technical stakeholders using plain language, map overlays and conceptual diagrams. Specialism in audience-span communication from engineer to senior executive.
 
 employment:
+  - title: Technical Project Manager
+    company: Oxford Dynamics
+    location: RAL Science Campus, Harwell, UK
+    period: Aug 2026 – Present
+
   - title: Technical Product Specialist
     company: Outdooractive
     location: Remote (UK · Immenstadt, Germany)
-    period: Sep 2023 – Present
+    period: Sep 2023 – Jul 2026
     highlights:
       - Contributed to product roadmap prioritisation across consumer-facing (B2C) and partner-facing product areas, providing structured input using RICE and MoSCoW frameworks to align delivery with business OKRs.
       - Reduced feature request support tickets by 59% through structured discovery, stakeholder interviews and user research that surfaced root causes and informed iterative product improvements.

--- a/src/data/defence.ts
+++ b/src/data/defence.ts
@@ -15,6 +15,7 @@ export interface GeoPoint {
 
 /** Matched against Role.location / Qualification.institution by substring. */
 const LOCATION_GEO: Array<{ pattern: RegExp; geo: GeoPoint }> = [
+  { pattern: /Harwell/i, geo: { lat: 51.5716, lng: -1.3122, label: 'HARWELL · GBR' } },
   { pattern: /Immenstadt/i, geo: { lat: 47.5606, lng: 10.2198, label: 'IMMENSTADT · DEU' } },
   { pattern: /Bovington/i, geo: { lat: 50.6974, lng: -2.2343, label: 'BOVINGTON · GBR' } },
   { pattern: /Chester/i, geo: { lat: 53.1905, lng: -2.8917, label: 'CHESTER · GBR' } },
@@ -32,8 +33,14 @@ function geoFor(text: string): GeoPoint | null {
   return hit ? hit.geo : null;
 }
 
+/** Companies worked hybrid/remote from home. The console draws an animated
+    home↔posting link for these and frames both ends together. */
+const HYBRID_COMPANIES = /Outdooractive|Oxford Dynamics/i;
+
 export interface GeoRole extends Role {
   geo: GeoPoint;
+  /** Hybrid/remote posting — rendered with a link back to the home station. */
+  hybrid: boolean;
 }
 
 export interface GeoQualification extends Qualification {
@@ -44,7 +51,7 @@ export interface GeoQualification extends Qualification {
 export const geoEmployment: GeoRole[] = cv.employment.map((role) => {
   const geo = geoFor(role.location);
   if (!geo) throw new Error(`defence.ts: no geo mapping for employment location "${role.location}"`);
-  return { ...role, geo };
+  return { ...role, geo, hybrid: HYBRID_COMPANIES.test(role.company) };
 });
 
 /** Education joined to institution sites (certifications stay non-geo). */


### PR DESCRIPTION
## Summary

- **New role.** Technical Project Manager at Oxford Dynamics, RAL Science Campus, Harwell, from Aug 2026. Outdooractive closed out at Jul 2026 (case-study year updated to match). No highlights on the new entry yet — both the experience card and the console already treat them as optional. Narrative, hero badge and "Based in" are unchanged.
- **Fixed a latent bug the new role exposed.** The console's animated remote-work arc was hardcoded to `roles[0]`, so adding a newer first role silently stole it from Outdooractive. Roles now carry a `hybrid` flag (`defence.ts`) and each hybrid posting draws its own home-linked arc, lighting the home pin when focused.
- **New domestic framing.** Oxford Dynamics frames the Winchester–Harwell–London centroid at camZ 5.6. London is geography, not a pin — dimmed career markers are grey dots, so a grey London dot would read as a job that never happened.
- **Rescaled three constants** that were tuned for a cross-continent hop and break at half a degree: arc lift (its floor was taller than the arc is long, giving a spike), dash pitch + march speed (a single dash exceeded the whole arc), and the marker-scale floor (pins and pulse rings merged into one blob). The Immenstadt link clamps to its original values and is pixel-unchanged.

## Test plan

- [x] `npm run build` — green, 36 pages
- [x] `tsc --noEmit` — clean
- [x] Outdooractive framing unchanged: Winchester↔Immenstadt arc, readout `49.3119° N / 4.4559° E`
- [x] Oxford Dynamics: both pins lit and distinct, arc marching, readout `51.3807° N / 0.9160° W`, coastline legible at county scale
- [x] Non-hybrid roles (Bovington/Chester/Cyprus) still frame on the posting alone, home pin dim
- [x] Desktop + mobile, no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)