### PR TITLE
fix(cv): compute the experience-years figure from the viewer's clock

### DIFF
--- a/src/components/DefenceConsole.tsx
+++ b/src/components/DefenceConsole.tsx
@@ -15,6 +15,8 @@ import {
 } from './DefenceGlobe';
 import { DefenceLedger, slugFromLink, designationChip, type LedgerProject } from './DefenceLedger';
 import { useTacticalAccent, accentToCss } from '../lib/useTacticalAccent';
+import { useExperienceYears } from '../lib/useExperienceYears';
+import { withExperienceYears } from '../lib/experience';
 
 gsap.registerPlugin(ScrollTrigger);
 
@@ -68,8 +70,13 @@ export interface ConsoleStat {
 
 export interface DefenceConsoleProps {
   badge: string;
+  /** Both of these still carry the raw [[experience_years]] placeholder — the
+      island substitutes it against the viewer's clock, not the build's. */
   profileText: string;
   stats: ConsoleStat[];
+  /** Build-time years figure: the first render's value, before the effect in
+      useExperienceYears corrects it to the viewer's own. */
+  experienceYears: string;
   roles: ConsoleRole[];
   competencies: ConsoleCompetency[];
   education: ConsoleQualification[];
@@ -766,8 +773,25 @@ const Half = ({ children }: { children: React.ReactNode }) => (
 /* ── Page ────────────────────────────────────────────────────────────────── */
 
 export default function DefenceConsole(props: DefenceConsoleProps) {
-  const { badge, profileText, stats, roles, competencies, education, certifications, projects, homeGeo, contact } =
-    props;
+  const {
+    badge,
+    profileText: rawProfile,
+    stats: rawStats,
+    experienceYears: buildYears,
+    roles,
+    competencies,
+    education,
+    certifications,
+    projects,
+    homeGeo,
+    contact,
+  } = props;
+  const years = useExperienceYears(buildYears);
+  const profileText = withExperienceYears(rawProfile, years);
+  const stats = useMemo(
+    () => rawStats.map((s) => ({ ...s, value: withExperienceYears(s.value, years) })),
+    [rawStats, years],
+  );
   const containerRef = useRef<HTMLDivElement>(null);
   const canvasWrapRef = useRef<HTMLDivElement>(null);
   const coordsRef = useRef<HTMLSpanElement>(null);

--- a/src/lib/experience.ts
+++ b/src/lib/experience.ts
@@ -14,7 +14,9 @@ export function experienceYearsText(now: Date = new Date()): string {
   return text;
 }
 
-/** Replace the [[experience_years]] placeholder used in cv.yml copy. */
-export function withExperienceYears(text: string, now: Date = new Date()): string {
-  return text.replace(/\[\[experience_years\]\]/g, experienceYearsText(now));
+/** Replace the [[experience_years]] placeholder used in cv.yml copy. Takes the
+    figure rather than a date so the caller decides which clock it came from —
+    the build's, or the viewer's (see useExperienceYears). */
+export function withExperienceYears(text: string, years: string = experienceYearsText()): string {
+  return text.replace(/\[\[experience_years\]\]/g, years);
 }

--- a/src/lib/useExperienceYears.ts
+++ b/src/lib/useExperienceYears.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+import { experienceYearsText } from './experience';
+
+/**
+ * The years-of-experience figure is derived from today's date, but the page is
+ * a static build and the Pages deploy only runs on a push to main. A site built
+ * in August renders "12" and would still say "12" the following September,
+ * until some unrelated commit happened to trigger a rebuild. Recomputing in the
+ * browser means the number is right on the day it changes — no rebuild, no
+ * scheduled job, no server.
+ *
+ * SSR-safe, on the same pattern as useTacticalAccent: the first client render
+ * reuses the build-time figure so the hydrated markup matches the server's,
+ * then an effect corrects it. The two only differ on a page whose build
+ * predates an anniversary, and then only by one digit.
+ */
+export function useExperienceYears(buildValue: string): string {
+  const [years, setYears] = useState(buildValue);
+  useEffect(() => setYears(experienceYearsText()), []);
+  return years;
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,11 +4,13 @@ import DefenceConsole from '../components/DefenceConsole.tsx';
 import { cv } from '../data/cv';
 import { appProjects } from '../data/projects';
 import { site } from '../data/site';
-import { withExperienceYears } from '../lib/experience';
+import { experienceYearsText } from '../lib/experience';
 import { geoEmployment, geoEducation, HOME_GEO } from '../data/defence';
 
-const profileText = withExperienceYears(cv.profile);
-const stats = cv.hero_stats.map((s) => ({ ...s, value: withExperienceYears(s.value) }));
+// Copy keeps its [[experience_years]] placeholder all the way into the island,
+// which substitutes against the viewer's clock. This is the build-time figure
+// it renders first, so the server markup and the first client render agree.
+const experienceYears = experienceYearsText();
 
 // Keep the island bundle lean: only the fields the ledger renders/sorts.
 const projects = appProjects.map((p) => ({
@@ -29,8 +31,9 @@ const projects = appProjects.map((p) => ({
     <DefenceConsole
       client:load
       badge={cv.hero_badge}
-      profileText={profileText}
-      stats={stats}
+      profileText={cv.profile}
+      stats={cv.hero_stats}
+      experienceYears={experienceYears}
       roles={geoEmployment}
       competencies={cv.competencies}
       education={geoEducation}


### PR DESCRIPTION
## Summary

- The years-of-experience figure was substituted in Astro frontmatter, so it was frozen at build time. Pages only deploys on a push to `main`, so it would **not** have rolled over to 13 on 1 Sep 2026 — it would have waited for whatever unrelated commit next triggered a rebuild.
- Copy now carries its `[[experience_years]]` placeholder into the island, which substitutes against `new Date()` in the browser. No backend, no scheduled job.
- `useExperienceYears` follows the same SSR-safe shape as the existing `useTacticalAccent`: the first render reuses the build-time figure so the hydrated markup matches the server's, then an effect corrects it.
- `withExperienceYears` now takes the figure rather than a `Date`, so the caller decides which clock it came from.

## Notes

- The static HTML still ships a real number, so a no-JS reader gets stale copy rather than a raw placeholder. The raw placeholder is now visible in page source inside the island's serialised props.
- The `+` suffix in `experienceYearsText` remains unreachable (`months = currentMonth - 9` maxes at 3, so `> 6` never fires). Pre-existing, inherited from the Jekyll Liquid port, deliberately left alone.

## Test plan

- [x] `npm run build` — green, 36 pages
- [x] **Correction path exercised, not just asserted:** built with a deliberately wrong figure (`99`) — static HTML shipped "99 years" ×2, loaded page rendered "12 years" ×2
- [x] No React hydration mismatch (only pre-existing THREE.Clock deprecation warnings from drei)
- [x] Rollover dates confirmed: 31 Aug 2026 → 12, 1 Sep 2026 → 13, 1 Sep 2027 → 14
- [x] No placeholder leaks into rendered text

🤖 Generated with [Claude Code](https://claude.com/claude-code)