### PR TITLE
fix(defence): lock the shipped-work section instead of clamping page scroll

### DIFF
--- a/src/components/DefenceConsole.tsx
+++ b/src/components/DefenceConsole.tsx
@@ -1003,24 +1003,49 @@ export default function DefenceConsole(props: DefenceConsoleProps) {
     };
   }, [openSlug, dossiers, openProject, projects]);
 
-  // While the dossier is open: snap the ledger into view, then keep page
-  // scroll LIVE but confined to the projects section — the list scrolls,
-  // the rest of the console stays out of reach. Plus ESC + focus.
+  // While the dossier is open: snap the ledger into view, then HARD-LOCK page
+  // scroll. The ledger docks to the viewport and scrolls its own rows
+  // (overscroll-contain), so navigating between assets stays live while the
+  // rest of the console is out of reach. Page scroll used to stay live and get
+  // clamped back on every scroll event — that fought inertial/momentum scroll
+  // (each snap-back re-fires scroll) and read as jitter. Freezing the scroller
+  // never rubber-bands, because there is nothing to correct.
   useEffect(() => {
     if (openProject === null) return;
     document.querySelector('[data-ledger]')?.scrollIntoView({ block: 'start' });
-    closeBtnRef.current?.focus();
 
-    const section = document.querySelector<HTMLElement>('[data-sec="projects"]');
-    const clamp = () => {
-      if (!section) return;
-      const min = section.getBoundingClientRect().top + window.scrollY;
-      const max = Math.max(min, min + section.offsetHeight - window.innerHeight);
-      const y = window.scrollY;
-      if (y < min) window.scrollTo(0, min);
-      else if (y > max) window.scrollTo(0, max);
+    // Positional lock, not just overflow:hidden. Hiding overflow stops the
+    // USER scrolling, but programmatic jumps (focus, a hash change, a
+    // ScrollTrigger refresh) still move the page — silently, since a hidden
+    // scroller fires no scroll event to correct from. Offsetting a fixed body
+    // by the locked distance leaves nothing to move: the ledger simply cannot
+    // drift off station while the dossier is open.
+    const html = document.documentElement;
+    const body = document.body;
+    const lockedY = window.scrollY;
+    const prev = {
+      htmlOverflow: html.style.overflow,
+      htmlPad: html.style.paddingRight,
+      position: body.style.position,
+      top: body.style.top,
+      left: body.style.left,
+      right: body.style.right,
+      width: body.style.width,
     };
-    window.addEventListener('scroll', clamp, { passive: true });
+    // Classic (non-overlay) scrollbars reserve width; replace it with padding
+    // so locking the scroller doesn't shift the layout sideways.
+    const gutter = window.innerWidth - html.clientWidth;
+    html.style.overflow = 'hidden';
+    if (gutter > 0) html.style.paddingRight = `${gutter}px`;
+    body.style.position = 'fixed';
+    body.style.top = `${-lockedY}px`;
+    body.style.left = '0';
+    body.style.right = '0';
+    body.style.width = '100%';
+
+    // Focus after the lock, with preventScroll — moving focus into the fixed
+    // panel is exactly the kind of jump that used to shift the page.
+    closeBtnRef.current?.focus({ preventScroll: true });
 
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') closeDossier();
@@ -1029,8 +1054,17 @@ export default function DefenceConsole(props: DefenceConsoleProps) {
     };
     window.addEventListener('keydown', onKey);
     return () => {
-      window.removeEventListener('scroll', clamp);
+      html.style.overflow = prev.htmlOverflow;
+      html.style.paddingRight = prev.htmlPad;
+      body.style.position = prev.position;
+      body.style.top = prev.top;
+      body.style.left = prev.left;
+      body.style.right = prev.right;
+      body.style.width = prev.width;
       window.removeEventListener('keydown', onKey);
+      // Release on the position the lock held — the ledger stays exactly where
+      // it was, rather than snapping to wherever the frozen scroller sat.
+      window.scrollTo(0, lockedY);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [openProject]);
@@ -1493,7 +1527,10 @@ export default function DefenceConsole(props: DefenceConsoleProps) {
           aria-label={`${projects[displayProject].name} — project dossier`}
         >
           {/* Reading panel — rides the centre split from the right */}
-          <div ref={panelRef} className="h-full overflow-y-auto border-l border-aluminum-500 bg-charcoal-900">
+          <div
+            ref={panelRef}
+            className="h-full overflow-y-auto overscroll-contain border-l border-aluminum-500 bg-charcoal-900"
+          >
             <div
               ref={panelContentRef}
               className={`w-full px-6 py-20 transition-all duration-300 ${

--- a/src/components/DefenceLedger.tsx
+++ b/src/components/DefenceLedger.tsx
@@ -138,11 +138,17 @@ export function DefenceLedger({ projects, onActiveProject, onOpenProject, openIn
   const toggleFilter = (key: string) =>
     setActiveFilters((prev) => (prev.includes(key) ? prev.filter((k) => k !== key) : [...prev, key]));
 
+  // With a dossier open the console freezes page scroll and snaps this block
+  // to the top of the viewport, so the ledger becomes its own scroll region:
+  // a fixed-height column whose rows scroll internally. That is what keeps the
+  // asset index navigable without the page trying to scroll underneath it.
+  const docked = openIndex !== null;
+
   return (
-    <div data-ledger>
+    <div data-ledger className={docked ? 'flex h-screen flex-col' : undefined}>
       {/* ── Bracket chip rail — kept inside the left half so it stays fully
              visible (and usable) while a dossier panel covers the right ── */}
-      <div className="mt-10 space-y-3 md:w-1/2 md:pr-12">
+      <div className={`mt-10 space-y-3 md:w-1/2 md:pr-12 ${docked ? 'shrink-0' : ''}`}>
         <div className="flex flex-wrap items-baseline gap-x-4 gap-y-2">
           <span className="t-kicker w-12">SORT</span>
           {SORTS.map((s) => (
@@ -169,7 +175,11 @@ export function DefenceLedger({ projects, onActiveProject, onOpenProject, openIn
 
       {/* ── Ledger rows. The two-half grid puts the title column's end on the
              viewport centre line — exactly the dossier panel's edge. ── */}
-      <div className="mt-8">
+      <div
+        className={`mt-8 ${
+          docked ? 'min-h-0 flex-1 overflow-y-auto overscroll-contain pb-16 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden' : ''
+        }`}
+      >
         {visible.map(({ p, originalIndex }) => {
           const slug = slugFromLink(p.link);
           const isOpen = openIndex === originalIndex;


### PR DESCRIPTION
## Problem

With a dossier open, the shipped-work list scrolled but felt jumpy and jittery. Page scroll stayed live and a `scroll` listener clamped it back into the projects section with `window.scrollTo`. On macOS, momentum scroll keeps firing scroll events after release, so every correction was re-fought by the next inertia frame — the fight is the jitter.

## Change

- Freeze page scroll while a dossier is open: `html { overflow: hidden }` plus a positional lock (`body { position: fixed; top: -lockedY }`), with scrollbar-gutter compensation so nothing shifts sideways.
- Dock the ledger to the viewport (`flex h-screen flex-col`): the sort/filter rail is pinned and the rows get their own `overflow-y-auto overscroll-contain` scroller, so navigating between assets stays live without the page moving underneath.
- `overscroll-contain` on the dossier panel too, so reading to the end of a dossier doesn't chain out.
- Focus moves into the panel with `preventScroll`; closing restores the exact prior scroll position.

`overflow:hidden` alone was not sufficient — it stops *user* scrolling but not programmatic jumps (focus, hash change, a ScrollTrigger refresh), and a hidden document scroller fires **no** scroll event, so a guard listener could never correct the drift. Hence the positional lock.

## Verification

Dev server, 1280×800 and 1024×560:

| Check | Result |
|---|---|
| Ledger docked while open | `top: 0`, height = viewport (800/800, 560/560) |
| List scrolls internally | scrollHeight 1084 vs client 608 (368 short viewport), `overscroll-behavior: contain` |
| Forced `scrollTo(0,0)` / `(0,99999)` | ledger stays at `top: 0` — no drift |
| Switch asset from a scrolled list | ledger pinned, list scroll position kept, dossier swapped |
| Close | `body` static, `overflow` visible, scroll restored, page scrolls freely |
| `tsc --noEmit` / `npm run build` | clean, 36 pages built |

🤖 Generated with [Claude Code](https://claude.com/claude-code)