### PR TITLE
content(peaking): v1.12 release entry

### DIFF
--- a/src/content/updates/peaking/v1-12.md
+++ b/src/content/updates/peaking/v1-12.md
@@ -1,0 +1,21 @@
+---
+app: peaking
+version: v1.12
+date: 2026-08-08
+title: v1.12 — One layout system behind every list
+summary: Every tab and detail view rebuilt on a shared section host, so sorting, filtering and display modes work the same way everywhere.
+---
+Peaks, summits, routes, collections, trails and achievements had each grown
+their own version of the same screen. They now share one compositional host:
+the same section headers, the same sort and filter menus promoted into the
+toolbar, and the same list, cards and gallery display modes, with sensible
+defaults per surface and a migration so existing choices carry over. "View
+all" destinations inherit the mode of the section they came from rather than
+resetting to a plain list. Cards mode got the attention it needed along the
+way — long-press now targets the card under your finger instead of the first
+one in the row, previews show real content, tiles are square, and favourite
+and pin badges render consistently across rows, cards and map annotations.
+Elsewhere: panning during an Aerial 3D orbit hands control straight back to
+you, trails cluster on the map and shift their icon into frame when only
+partly visible, and an expanded weather day covers the whole day rather than
+cutting off before sunset.


### PR DESCRIPTION
Adds `src/content/updates/peaking/v1-12.md` — the Peaking v1.12 entry for the dev log.

Drawn from the closed v1.12 milestone (96 issues): the unified dynamic section layout epic (`SectionedContentHost` — shared section headers, toolbar-promoted sort/filter, list/cards/gallery display modes with per-surface defaults and a migration, view-all mode inheritance), the cards-mode corrections that came with it (long-press targeting, real previews, square tiles, consistent favourite/pin badges), plus Aerial 3D pan-to-take-control, trails clustering and in-frame icon relocation, and the full-day weather expansion.

Dated 2026-08-08, when the milestone closed. Note there is no `v1.12.0` tag in the Peaking repo — that work reached external TestFlight under today's `v1.13.0` tag, having run as internal builds 947–961.

🤖 Generated with [Claude Code](https://claude.com/claude-code)