### PR TITLE
content(peaking): v1.13 release entry

### DIFF
--- a/src/content/updates/peaking/v1-13.md
+++ b/src/content/updates/peaking/v1-13.md
@@ -1,0 +1,21 @@
+---
+app: peaking
+version: v1.13
+date: 2026-08-08
+title: v1.13 — Pinning that holds, and a calmer first run
+summary: Pinned content stays put and sorts first across every list, and launch explains what it is still doing.
+---
+Pinning became a promise rather than a preference. Pinned peaks, routes,
+summits, collections and trails now stay in the "in view" lists even when the
+map has moved off them, and they sort to the top with an animation — the same
+rule on every content type, annotated in the sort menu so it isn't a surprise.
+Launch and onboarding got their own pass: the step icons animate the search
+they describe and take their colours from the map, work that carries on in the
+background after launch is surfaced as a summary card with a post-launch
+indicator, and widget deep links survive a cold start instead of being dropped
+while the launch views still own the screen. Aerial 3D gave up its orbit and
+became a map style you stay in control of — satellite imagery, elevation and a
+steep pitch, held rather than animated at you. Trails read better on the map
+too, with the right cluster colour, an in-view list that matches what is
+actually on screen, and faster annotations. Strava activity titles no longer
+risk leading with a street address.


### PR DESCRIPTION
Adds `src/content/updates/peaking/v1-13.md`, following [#162](https://github.com/liammday/liamday-site/pull/162).

Drawn from the closed v1.13 milestone (80 issues): pinning made universal (pinned content persists in in-view lists and sorts first, animated, across all content types, annotated in the sort menu), the launch & onboarding epic (animated step icons on the map palette, deferred/background-continuing work surfaced as a summary card + post-launch indicator, widget deep links surviving cold launch), Aerial 3D trading its orbit for a persistent satellite/elevation/steep-pitch map style, trail map corrections (cluster colour, accurate in-view list, annotation performance), and the Strava title privacy fix.

Dated 2026-08-08 — the `v1.13.0` tag date. It shares that date with the v1.12 entry; the timeline sorts by date and falls back to file order, which puts v1.12 before v1.13 as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)