### PR TITLE
fix(updates): break same-date timeline ties by version, then id

### DIFF
--- a/src/components/UpdateTimeline.astro
+++ b/src/components/UpdateTimeline.astro
@@ -22,8 +22,38 @@ interface Props {
 
 const { updates, collapsible = false, label = 'Updates', linkTitles = true } = Astro.props;
 
-// Oldest to newest, so updates read chronologically down the page after the main body.
-const sorted = [...updates].sort((a, b) => (a.date?.getTime() ?? 0) - (b.date?.getTime() ?? 0));
+/** "v1.12" / "v2.0.0" → [1, 12, 0] — numeric per segment, so v1.10 > v1.9. */
+function versionParts(version?: string): number[] {
+  if (!version) return [];
+  return version
+    .replace(/^v/i, '')
+    .split('.')
+    .map((s) => parseInt(s, 10) || 0);
+}
+
+function compareVersions(a?: string, b?: string): number {
+  // Unversioned entries (narrative posts) sort before versioned ones the same
+  // day: a release is the day's conclusion, not its opening.
+  if (!a || !b) return (a ? 1 : 0) - (b ? 1 : 0);
+  const pa = versionParts(a);
+  const pb = versionParts(b);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const diff = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+// Oldest to newest, so updates read chronologically down the page after the main
+// body. Two releases can share a date (v1.12 and v1.13 both landed 2026-08-08),
+// so version breaks the tie rather than leaving it to file order, and the id
+// settles anything still equal — the order is deliberate, not incidental.
+const sorted = [...updates].sort(
+  (a, b) =>
+    (a.date?.getTime() ?? 0) - (b.date?.getTime() ?? 0) ||
+    compareVersions(a.version, b.version) ||
+    (a.id ?? '').localeCompare(b.id ?? ''),
+);
 
 function fmt(d?: Date): string {
   return d ? d.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' }) : '';


### PR DESCRIPTION
## Problem

`UpdateTimeline` sorted entries by date alone. v1.12 and v1.13 both carry `2026-08-08`, so their order fell to the collection loader's file order — correct by luck, not by decision.

## Change

Same-date ties now break on version, compared numerically per segment (`v1.10` follows `v1.9`, not `v1.1`; `v1.0` and `v1.0.0` are equal), then on id so the order is fully determined. Unversioned narrative entries sort ahead of a versioned release on the same day — a release reads as the day's conclusion.

## Verification

Comparator unit cases (9/9 pass): `v1.9 < v1.10`, `v1.12 < v1.13`, `v1.0 == v1.0.0`, `v2.0.0 > v1.13`, `v1.7.5 > v1.7`, and each undefined permutation.

Rendered order on the dev server:

- **/projects/peaking/** — five unversioned narrative entries, then v1.0 → v1.13 ascending, with v1.9 before v1.10 and v1.12 before v1.13.
- **/projects/rallying/**, **/projects/training/**, **/projects/claude-usage-pacer/** — unchanged, still chronological.

`tsc --noEmit` clean; `npm run build` builds 36 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)