### PR TITLE
feat(gallery): screenshot carousel uses the full width available, and keeps its device radius

### DIFF
--- a/src/components/DefenceConsole.tsx
+++ b/src/components/DefenceConsole.tsx
@@ -1533,6 +1533,12 @@ export default function DefenceConsole(props: DefenceConsoleProps) {
           >
             <div
               ref={panelContentRef}
+              // The mode drives the screenshot carousel's breakout: in half
+              // mode the reading column is left-anchored inside a wider sheet,
+              // so the strip reclaims the dead space to its right (see
+              // .app-gallery in global.css). Expanded mode is centred and has
+              // none to reclaim.
+              data-dossier-width={expanded ? 'full' : 'half'}
               className={`w-full px-6 py-20 transition-all duration-300 ${
                 expanded ? 'md:mx-auto md:max-w-3xl' : 'md:max-w-xl md:pl-14'
               }`}

--- a/src/components/ui/AppScreenshotGallery.astro
+++ b/src/components/ui/AppScreenshotGallery.astro
@@ -29,10 +29,13 @@ const items = screenshots
 
 <section id="screenshots" class="py-8">
   <h2 class="sr-only">Screenshots</h2>
-  {/* Full-bleed scroll: the track spans the viewport while `page-nav-bleed` keeps the
-      first item aligned to the column (same pattern as the sticky sub-nav). The vertical
-      padding gives the image drop-shadow room so `overflow-x-auto` doesn't clip it. */}
-  <ul class="app-gallery page-nav-bleed flex gap-4 overflow-x-auto pt-2 pb-8" aria-label={`${title} screenshots`}>
+  {/* Full-bleed scroll: the track spans whatever width it is given — the viewport on a
+      project page, the sheet inside the /defence dossier — with only a page gutter, so
+      wide screens show more shots rather than padding them into the text column. The
+      track centres itself when the row fits (`safe center` degrades to flex-start once
+      it overflows, keeping the first item reachable). The vertical padding gives the
+      image drop-shadow room so `overflow-x-auto` doesn't clip it. */}
+  <ul class="app-gallery flex gap-4 overflow-x-auto px-6 pt-2 pb-8" aria-label={`${title} screenshots`}>
     {
       items.map((it, i) => (
         <li class="app-gallery__item shrink-0">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -157,10 +157,27 @@ const projects = appProjects.map((p) => ({
     padding-right: 0;
     margin-top: 3.5rem;
   }
-  /* Gallery bleed helper is tuned for the standalone page's centred column;
-     inside the panel just pad it like the rest of the content. */
-  [data-tactical] .dossier-article .page-nav-bleed {
-    padding-left: 0;
-    padding-right: 0;
+  /* Screenshots are device captures, not case-study figures: they keep the
+     iPhone's own display radius (26px at the 440px render height, #134) rather
+     than squaring off with the rest of the injected content. Without this the
+     rule above strips the very thing that makes them read as a phone. */
+  [data-tactical] .dossier-article .app-gallery img {
+    border-radius: 26px;
+  }
+
+  /* The strip spans the whole sheet, not the reading column it is nested in.
+     Half mode: the column is left-anchored (pl-14) inside a 50vw sheet, so
+     reclaim that inset plus the dead space to its right. Expanded mode: the
+     column is centred in a full-width sheet, so reclaim both sides equally.
+     Either way the sheet keeps its own 1.5rem gutter, and `max()` collapses
+     the breakout to nothing once the sheet is no wider than the column. */
+  @media (min-width: 768px) {
+    [data-dossier-width='half'] .app-gallery {
+      margin-left: -2rem; /* pl-14 (3.5rem) back to the 1.5rem gutter */
+      margin-right: calc(-1 * max(0px, 50vw - 36rem));
+    }
+    [data-dossier-width='full'] .app-gallery {
+      margin-inline: calc(-1 * max(0px, (100vw - 48rem) / 2));
+    }
   }
 </style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -477,6 +477,14 @@
   /* ── App screenshot gallery (horizontal scroll with snap) ─────────────────── */
   .app-gallery {
     scroll-snap-type: x proximity;
+    /* Use the width on offer: centre the row while it fits, and fall back to
+       flex-start the moment it overflows. Plain `center` would push the first
+       item past the scroll origin and make it unreachable; `safe` is what
+       makes centring usable inside a scroll container. */
+    justify-content: safe center;
+    /* Snapping ignores padding, so without this the first shot lands flush to
+       the container edge instead of on the page gutter it was laid out on. */
+    scroll-padding-inline: 1.5rem;
     /* Hide the scrollbar to match the sticky sub-nav ([data-nav-scroll]); the
        scroll mechanism (wheel, touch, drag) still works, just no visible bar. */
     scrollbar-width: none;


### PR DESCRIPTION
## Change

**Project page** — the track carried `page-nav-bleed`, which padded it into the text column (325px a side at 1627px wide) and forced scrolling for five shots that fit easily. It now takes a page gutter and centres with `justify-content: safe center` (degrading to flex-start on real overflow, so the first shot stays reachable), with `scroll-padding-inline` keeping the snap position on the gutter.

**/defence dossier** — the strip inherited the reading column (496px of an 814px sheet). It now spans the sheet in both modes: half mode reclaims the column's left inset and the dead space beside it, expanded mode reclaims both sides. `max()` collapses the breakout when the sheet is no wider than the column.

**Corner radius** — `[data-tactical] .dossier-article img { border-radius: 0 }` squared off the screenshots along with the case-study figures. These are device captures, and 26px is the iPhone's own display radius at the 440px render height (set in #134), so they're now exempt.

## Measurements

| Surface | Before | After |
|---|---|---|
| Project page @1330px | overflowed, 325px padding a side | 1083px row centred, no scroll |
| Project page @900px | — | overflows, first shot at the 24px gutter, snap origin 0 |
| Dossier half sheet (814px) | gallery 496px | gallery 766px, gutters 25/23 |
| Dossier expanded (1627px) | column-capped | gallery 1579px, gutters 25/24, no overflow |
| Dossier screenshot radius | `0px` | `26px` |

Project page radius was already 26px and is unchanged. Mobile (<768px) keeps the plain column padding — the breakout is behind `min-width: 768px`.

`tsc --noEmit` clean; `npm run build` builds 36 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)