### PR TITLE
content: Peaking v1.13 + v1.14 release entries

### DIFF
--- a/src/content/updates/peaking/v1-13.md
+++ b/src/content/updates/peaking/v1-13.md
@@ -2,20 +2,16 @@
 app: peaking
 version: v1.13
 date: 2026-08-08
-title: v1.13 — Pinning that holds, and a calmer first run
-summary: Pinned content stays put and sorts first across every list, and launch explains what it is still doing.
+title: v1.13 — A QA-driven polish sweep, and the map keeps your style
+summary: A day of rapid-fire fixes from a full QA pass, plus a persistent 3D map style and sharper pinned-peak behaviour.
 ---
-Pinning became a promise rather than a preference. Pinned peaks, routes,
-summits, collections and trails now stay in the "in view" lists even when the
-map has moved off them, and they sort to the top with an animation — the same
-rule on every content type, annotated in the sort menu so it isn't a surprise.
-Launch and onboarding got their own pass: the step icons animate the search
-they describe and take their colours from the map, work that carries on in the
-background after launch is surfaced as a summary card with a post-launch
-indicator, and widget deep links survive a cold start instead of being dropped
-while the launch views still own the screen. Aerial 3D gave up its orbit and
-became a map style you stay in control of — satellite imagery, elevation and a
-steep pitch, held rather than animated at you. Trails read better on the map
-too, with the right cluster colour, an in-view list that matches what is
-actually on screen, and faster annotations. Strava activity titles no longer
-risk leading with a street address.
+This cut closed out two buckets of work in one external release. The
+visible thread is polish that came straight from a full QA run: links
+into the app land where they should, pinned peaks and "in view" logic
+agree with what the map is actually showing, toolbars carry proper
+titles, and route names imported from Strava no longer leak details you
+might not want shared. The map also learned to keep its style — if you
+prefer the 3D terrain view, it stays that way between launches instead
+of resetting. Under the surface, an always-on performance log now keeps
+a short rolling record of what the app was doing, so slow moments can be
+diagnosed from a real device instead of guesswork.

--- a/src/content/updates/peaking/v1-14.md
+++ b/src/content/updates/peaking/v1-14.md
@@ -1,0 +1,20 @@
+---
+app: peaking
+version: v1.14
+date: 2026-08-23
+title: v1.14 — Plants & Wildlife arrive, and empty tiles get real photos
+summary: A species catalogue with a sighting log joins the app, photo-less peaks pull openly licensed photos, and the iPad layout grows up.
+---
+The headline is a whole new dimension: Plants & Wildlife. Browse a
+species catalogue with its own icons and common names, log a sighting in
+two taps from the new tab, and see your sightings plotted on the map in
+their own colours — with sensitive species kept location-private, and
+sightings shareable with friends on the same terms as summits. Alongside
+it, peaks, routes and collections that had no photo now pull an openly
+licensed picture from Wikimedia Commons, credited and linked, so the
+browse screens stop being a wall of grey gradients. iPad users get a
+proper regular-width layout — sidebar, floating map controls and
+column toolbars instead of a stretched phone screen. And a set of
+sync fixes means favourites, pins and renames now genuinely travel
+between your devices, backed by groundwork that measures launch and
+background performance on real hardware for the releases ahead.


### PR DESCRIPTION
Ceremony C1b for Peaking v1.14.0 (external, 2026-08-23) — plus the v1.13 backfill that slipped at its own ceremony. `npx astro build` passes (36 pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)